### PR TITLE
ref: create dedicated container for mom

### DIFF
--- a/scripts/input-orca.py
+++ b/scripts/input-orca.py
@@ -1,5 +1,4 @@
-from calcflow.io.input import CalculationInput
-
+from calcflow.common.input import CalculationInput
 from calcflow.geometry.static import Geometry
 
 # from calcflow.jobs.slurm import SlurmJob

--- a/src/calcflow/common/input.py
+++ b/src/calcflow/common/input.py
@@ -46,6 +46,38 @@ class OptimizationSpec:
     recalc_hess_freq: int | None = None
 
 
+@dataclass(frozen=True)
+class MomSpec:
+    """
+    specification for maximum overlap method (mom) calculations.
+
+    mom is a technique to converge scf to excited states or non-aufbau configurations
+    by guiding orbital occupations. requires a two-job input: job1 computes ground state
+    orbitals, job2 uses those orbitals with modified occupations to reach the target state.
+
+    transition notation supports both symbolic and numeric orbital specifications:
+    - symbolic: "HOMO->LUMO", "HOMO-1->LUMO+1", "HOMO-2->LUMO"
+    - numeric: "5->6", "3->LUMO", "HOMO->7" (absolute orbital indices)
+    - ionization: "HOMO->vac", "5->vac" (remove electron)
+    - spin-specific: "HOMO(beta)->LUMO(alpha)", "5(alpha)->vac"
+    - multiple transitions: "HOMO->LUMO; HOMO-1->LUMO+1" (semicolon-separated)
+
+    for ionization, job2_charge and job2_spin_multiplicity should be set to match
+    the ionized state (e.g., charge +1, multiplicity 2 for a neutral singlet -> cation doublet).
+    """
+
+    transition: str
+    method: str = "IMOM"  # or "MOM"
+
+    # for ionization: override charge/spin in second job
+    job2_charge: int | None = None
+    job2_spin_multiplicity: int | None = None
+
+    # manual override for advanced users (bypasses symbolic transition parsing)
+    alpha_occupation: str | None = None
+    beta_occupation: str | None = None
+
+
 # --- Main Calculation Specification ---
 
 
@@ -71,6 +103,7 @@ class CalculationInput:
     tddft: TddftSpec | None = None
     solvation: SolvationSpec | None = None
     optimization: OptimizationSpec | None = None
+    mom: MomSpec | None = None
     frequency_after_optimization: bool = False
 
     # the escape hatch for anything program-specific that doesn't fit the generic model.
@@ -87,6 +120,18 @@ class CalculationInput:
             raise ValidationError("tddft nroots must be a positive integer.")
         if self.solvation and (not self.solvation.model or not self.solvation.solvent):
             raise ValidationError("solvation model and solvent must both be specified.")
+        if self.mom:
+            if not self.unrestricted:
+                raise ValidationError("mom requires an unrestricted calculation.")
+            if not self.mom.transition and not (self.mom.alpha_occupation and self.mom.beta_occupation):
+                raise ValidationError(
+                    "mom requires either 'transition' or both 'alpha_occupation' and 'beta_occupation'."
+                )
+
+    @property
+    def requires_multiple_jobs(self) -> bool:
+        """returns true if this calculation requires multiple sequential jobs (e.g., for mom)."""
+        return self.mom is not None
 
     # --- Core Parameter Setters ---
 
@@ -162,6 +207,34 @@ class CalculationInput:
         if self.task != "geometry":
             raise ConfigurationError("frequency calculation can only follow a 'geometry' task.")
         return replace(self, frequency_after_optimization=True)
+
+    def set_mom(
+        self: T_CalculationInput,
+        transition: str,
+        method: str = "IMOM",
+        job2_charge: int | None = None,
+        job2_spin_multiplicity: int | None = None,
+    ) -> T_CalculationInput:
+        """
+        adds or updates maximum overlap method (mom) settings for excited state calculations.
+
+        mom requires a two-job calculation and unrestricted wavefunctions.
+
+        args:
+            transition: transition string supporting symbolic (e.g., "HOMO->LUMO") or
+                numeric (e.g., "5->6", "3->LUMO") orbital specifications.
+                use "->vac" for ionization (e.g., "HOMO->vac", "5->vac").
+            method: mom variant ("MOM" or "IMOM", default "IMOM")
+            job2_charge: charge for second job (for ionization, e.g., +1)
+            job2_spin_multiplicity: spin multiplicity for second job (for ionization, e.g., 2)
+        """
+        mom_spec = MomSpec(
+            transition=transition,
+            method=method,
+            job2_charge=job2_charge,
+            job2_spin_multiplicity=job2_spin_multiplicity,
+        )
+        return replace(self, mom=mom_spec)
 
     # --- Program-Specific Options ---
 

--- a/src/calcflow/io/qchem/builder.py
+++ b/src/calcflow/io/qchem/builder.py
@@ -20,60 +20,90 @@ class QchemBuilder:
     def build(self, spec: CalculationInput, geometry: Geometry) -> str:
         """
         the main build method. orchestrates the creation of the input file.
-        handles the special case for mom, which requires a two-job input.
+        delegates to specialized builders based on whether multiple jobs are required.
         """
         self._validate_spec(spec)
-        opts = spec.program_options
-        is_mom = opts.get("run_mom", False)
 
-        # --- build the first job ---
-        # for mom, the first job is always a simple energy calculation to get the orbitals.
-        task_for_job1 = "energy" if is_mom else spec.task
-        rem_job1 = self._build_rem(spec, task_override=task_for_job1)
+        if spec.requires_multiple_jobs:
+            return self._build_multi_job_input(spec, geometry)
+        else:
+            return self._build_single_job_input(spec, geometry)
 
-        blocks_job1 = [
+    def _build_single_job_input(self, spec: CalculationInput, geometry: Geometry) -> str:
+        """builds a standard single-job input file."""
+        blocks = [
             self._build_molecule(spec, geometry),
-            rem_job1,
+            self._build_rem(spec),
             self._build_basis(spec),
             self._build_solvation_blocks(spec),
-            self._build_solute(spec) if not is_mom else "",
+            self._build_solute(spec),
         ]
-        job1_str = "\n\n".join(block for block in blocks_job1 if block)
+        return "\n\n".join(block for block in blocks if block).strip() + "\n"
 
-        if not is_mom:
-            return job1_str.strip() + "\n"
+    def _build_multi_job_input(self, spec: CalculationInput, geometry: Geometry) -> str:
+        """
+        builds a multi-job input file (e.g., for mom).
+        currently only supports mom, but structured to allow future extensions.
+        """
+        if spec.mom:
+            return self._build_mom_input(spec, geometry)
+        else:
+            raise NotSupportedError("multi-job calculations are currently only supported for mom.")
 
-        # --- if mom, build the second job ---
-        rem_job2 = self._build_rem(
-            spec,
-            scf_guess="read",
-            mom_start=True,
-            force_unrestricted=True,
-            task_override="energy",  # the second job of a mom is always a single point calc of the excited state
+    def _build_mom_input(self, spec: CalculationInput, geometry: Geometry) -> str:
+        """
+        builds a two-job mom input file.
+        job 1: ground state calculation to generate reference orbitals.
+        job 2: excited state calculation with modified orbital occupations.
+        """
+        job1 = self._build_mom_job1(spec, geometry)
+        job2 = self._build_mom_job2(spec, geometry)
+        return f"{job1}\n\n@@@\n\n{job2}\n"
+
+    def _build_mom_job1(self, spec: CalculationInput, geometry: Geometry) -> str:
+        """builds the first job for mom: ground state reference calculation."""
+        blocks = [
+            self._build_molecule(spec, geometry),
+            self._build_rem(spec, task_override="energy"),
+            self._build_basis(spec),
+            self._build_solvation_blocks(spec),
+            # no $solute block in job1 (tddft only runs in job2)
+        ]
+        return "\n\n".join(block for block in blocks if block).strip()
+
+    def _build_mom_job2(self, spec: CalculationInput, geometry: Geometry) -> str:
+        """builds the second job for mom: excited state with target occupations."""
+        assert spec.mom is not None
+
+        # determine charge/spin for job2 (may differ for ionization)
+        charge_job2 = spec.mom.job2_charge if spec.mom.job2_charge is not None else spec.charge
+        mult_job2 = (
+            spec.mom.job2_spin_multiplicity if spec.mom.job2_spin_multiplicity is not None else spec.spin_multiplicity
         )
-        # check for overrides for job2 charge/spin, common for ionization
-        charge_job2 = opts.get("mom_job2_charge", spec.charge)
-        mult_job2 = opts.get("mom_job2_spin_multiplicity", spec.spin_multiplicity)
 
-        blocks_job2 = [
+        blocks = [
             self._build_molecule(spec, geometry, charge_override=charge_job2, mult_override=mult_job2, read_geom=True),
-            rem_job2,
+            self._build_rem(spec, scf_guess="read", mom_start=True, task_override="energy"),
             self._build_basis(spec),
             self._build_solvation_blocks(spec),
             self._build_occupied_block(spec, geometry),
-            self._build_solute(spec),  # solute block for tddft from mom state
+            self._build_solute(spec),  # tddft excitations from the mom state
         ]
-        job2_str = "\n\n".join(block for block in blocks_job2 if block)
-
-        return f"{job1_str.strip()}\n\n@@@\n\n{job2_str.strip()}\n"
+        return "\n\n".join(block for block in blocks if block).strip()
 
     def _validate_spec(self, spec: CalculationInput):
         """performs q-chem-specific validation on the spec."""
         if spec.solvation and spec.solvation.model not in {"pcm", "smd", "isosvp", "cpcm"}:
             raise NotSupportedError(f"q-chem builder does not support solvation model '{spec.solvation.model}'.")
-        opts = spec.program_options
-        if opts.get("run_mom", False) and not spec.unrestricted:
+
+        # mom validation (should already be caught by CalculationInput.__post_init__, but double-check)
+        if spec.mom and not spec.unrestricted:
             raise ConfigurationError("mom requires an unrestricted calculation. use .set_unrestricted()")
+
+        # program_options validation (for backward compatibility during transition)
+        opts = spec.program_options
+        if opts.get("run_mom", False):
+            raise ConfigurationError("program_options['run_mom'] is deprecated. use .set_mom() instead.")
         if opts.get("reduced_excitation_space_orbitals") and not spec.tddft:
             raise ConfigurationError("reduced excitation space requires tddft to be enabled.")
 
@@ -97,7 +127,6 @@ class QchemBuilder:
         spec: CalculationInput,
         scf_guess: str | None = None,
         mom_start: bool = False,
-        force_unrestricted: bool = False,
         task_override: str | None = None,
     ) -> str:
         rem_vars: dict[str, str | bool | int] = {}
@@ -118,7 +147,7 @@ class QchemBuilder:
             raise NotSupportedError(f"level of theory '{method}' not supported by q-chem builder.")
 
         rem_vars["BASIS"] = "gen" if isinstance(spec.basis_set, dict) else spec.basis_set
-        rem_vars["UNRESTRICTED"] = spec.unrestricted or force_unrestricted
+        rem_vars["UNRESTRICTED"] = spec.unrestricted
         rem_vars["SYMMETRY"] = False
         rem_vars["SYM_IGNORE"] = True
 
@@ -127,13 +156,13 @@ class QchemBuilder:
             rem_vars["SCF_GUESS"] = scf_guess
         if mom_start:
             rem_vars["MOM_START"] = 1
-            rem_vars["MOM_METHOD"] = opts.get("mom_method", "IMOM")
+            rem_vars["MOM_METHOD"] = spec.mom.method if spec.mom else "IMOM"
 
         # --- tddft ---
         if spec.tddft:  # noqa: SIM102
             # tddft block is only added to the *final* calculation step
             # i.e., the first job if not mom, or the second job if mom
-            if not opts.get("run_mom", False) or mom_start:
+            if not spec.mom or mom_start:
                 rem_vars["CIS_N_ROOTS"] = spec.tddft.nroots
                 rem_vars["CIS_SINGLETS"] = spec.tddft.singlets
                 rem_vars["CIS_TRIPLETS"] = spec.tddft.triplets
@@ -187,35 +216,36 @@ class QchemBuilder:
 
     def _build_occupied_block(self, spec: CalculationInput, geometry: Geometry) -> str:
         """generates the $occupied block for mom calculations."""
-        opts = spec.program_options
-        if not opts.get("run_mom", False):
+        if not spec.mom:
             return ""
 
         if not spec.unrestricted:
             # this check is redundant with _validate_spec, but good for defense
             raise ConfigurationError("mom requires an unrestricted calculation. use .set_unrestricted()")
 
-        # determine charge/multiplicity for this specific job, allowing overrides for job 2
-        effective_charge = opts.get("mom_job2_charge", spec.charge)
-        effective_multiplicity = opts.get("mom_job2_spin_multiplicity", spec.spin_multiplicity)
+        # determine charge/multiplicity for this specific job (may differ for ionization)
+        effective_charge = spec.mom.job2_charge if spec.mom.job2_charge is not None else spec.charge
+        effective_multiplicity = (
+            spec.mom.job2_spin_multiplicity if spec.mom.job2_spin_multiplicity is not None else spec.spin_multiplicity
+        )
         total_electrons = geometry.total_nuclear_charge - effective_charge
 
-        mom_transition = opts.get("mom_transition")
-        if mom_transition == "GROUND_STATE":
+        # check for manual occupation override
+        if spec.mom.alpha_occupation and spec.mom.beta_occupation:
+            alpha_occ = spec.mom.alpha_occupation
+            beta_occ = spec.mom.beta_occupation
+        elif spec.mom.transition == "GROUND_STATE":
+            # special case: ground state occupation (for testing/validation)
             if total_electrons % 2 != 0:
                 raise ConfigurationError("mom 'GROUND_STATE' requires an even number of electrons.")
             n_occ = total_electrons // 2
             alpha_occ = beta_occ = f"1:{n_occ}" if n_occ > 1 else "1"
-        elif mom_transition:
+        elif spec.mom.transition:
             # handle symbolic transitions like "HOMO->LUMO" or "5(beta)->vac"
-            alpha_occ, beta_occ = self._convert_extended_transitions_to_occupations(mom_transition, spec, geometry)
-        elif "mom_alpha_occ" in opts and "mom_beta_occ" in opts:
-            # use explicitly provided occupation strings
-            alpha_occ = opts["mom_alpha_occ"]
-            beta_occ = opts["mom_beta_occ"]
+            alpha_occ, beta_occ = self._convert_extended_transitions_to_occupations(spec.mom.transition, spec, geometry)
         else:
             raise ConfigurationError(
-                "for mom, must specify `mom_transition` or provide `mom_alpha_occ` and `mom_beta_occ` in program_options."
+                "mom requires either 'transition' or both 'alpha_occupation' and 'beta_occupation'."
             )
 
         self._validate_mom_occupations(alpha_occ, beta_occ, total_electrons, effective_multiplicity)
@@ -293,14 +323,38 @@ class QchemBuilder:
             return initial_homo + 1 + offset if operator == "+" else initial_homo + 1
 
     def _apply_ionization(self, source_idx: int, spin: str | None, alpha_occ: set[int], beta_occ: set[int]) -> None:
+        """
+        removes an electron from the specified orbital for ionization transitions (e.g., "HOMO->vac").
+
+        spin channel selection logic:
+        1. if spin is explicitly specified ("alpha" or "beta"), remove from that channel
+        2. if spin is unspecified (none), prefer removing from beta, then fall back to alpha
+        3. raise error if the orbital is unoccupied in the target channel
+
+        rationale for preferring beta when spin is unspecified:
+        - for closed-shell ground states (alpha == beta initially), ionizing from beta
+          leaves the unpaired electron in alpha (spin-up by convention)
+        - this matches the typical chemical interpretation: cation radicals from
+          closed-shell neutrals are usually represented with alpha (spin-up) unpaired electrons
+        - example: h2o (singlet, 10e) -> h2o+ (doublet, 9e) with unpaired electron in alpha
+
+        """
         if spin == "alpha":
+            if source_idx not in alpha_occ:
+                raise ValidationError(f"cannot ionize from unoccupied alpha orbital {source_idx}")
             alpha_occ.remove(source_idx)
-        elif spin == "beta" or source_idx in beta_occ:
+        elif spin == "beta":
+            if source_idx not in beta_occ:
+                raise ValidationError(f"cannot ionize from unoccupied beta orbital {source_idx}")
             beta_occ.remove(source_idx)
-        elif source_idx in alpha_occ:
-            alpha_occ.remove(source_idx)
         else:
-            raise ValidationError(f"cannot ionize from unoccupied orbital {source_idx}")
+            # no spin specified: prefer beta (closed-shell convention), fall back to alpha
+            if source_idx in beta_occ:
+                beta_occ.remove(source_idx)
+            elif source_idx in alpha_occ:
+                alpha_occ.remove(source_idx)
+            else:
+                raise ValidationError(f"cannot ionize from unoccupied orbital {source_idx}")
 
     def _apply_excitation(
         self,

--- a/tests/io/qchem/qchem_builders/test_builder_mom.py
+++ b/tests/io/qchem/qchem_builders/test_builder_mom.py
@@ -17,7 +17,7 @@ from dataclasses import replace
 
 import pytest
 
-from calcflow.common.exceptions import ConfigurationError, ValidationError
+from calcflow.common.exceptions import ValidationError
 from calcflow.common.input import CalculationInput
 from calcflow.io.qchem.builder import QchemBuilder
 from tests.io.qchem.qchem_builders.conftest import (
@@ -123,8 +123,7 @@ def test_apply_single_operation_homo_lumo_excitation(h2o_geometry):
         level_of_theory="b3lyp",
         basis_set="6-31g",
         unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    ).set_mom(transition="HOMO->LUMO")
     builder._validate_spec(spec)
 
     alpha_occ = {1, 2, 3, 4, 5}
@@ -150,8 +149,7 @@ def test_apply_single_operation_homo_homo1_excitation(h2o_geometry):
         level_of_theory="b3lyp",
         basis_set="6-31g",
         unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO-1->LUMO+1"},
-    )
+    ).set_mom(transition="HOMO-1->LUMO+1")
     builder._validate_spec(spec)
 
     alpha_occ = {1, 2, 3, 4, 5}
@@ -177,8 +175,7 @@ def test_apply_ionization_from_homo(h2o_geometry):
         level_of_theory="b3lyp",
         basis_set="6-31g",
         unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->vac"},
-    )
+    ).set_mom(transition="HOMO->vac")
     builder._validate_spec(spec)
 
     alpha_occ = {1, 2, 3, 4, 5}
@@ -205,8 +202,7 @@ def test_apply_ionization_from_beta():
         level_of_theory="b3lyp",
         basis_set="6-31g",
         unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO(beta)->vac"},
-    )
+    ).set_mom(transition="HOMO(beta)->vac")
     builder._validate_spec(spec)
 
     alpha_occ = {1, 2, 3, 4, 5}
@@ -257,11 +253,7 @@ def test_format_occupation_set_empty():
 @pytest.mark.contract
 def test_mom_two_job_structure(qchem_builder, h2o_geometry, minimal_spec):
     """mom calculation should generate two-job structure separated by @@@."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
 
     # Verify two-job structure
@@ -278,11 +270,7 @@ def test_mom_two_job_structure(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job1_simple_sp(qchem_builder, h2o_geometry, minimal_spec):
     """job1 of mom calculation should be a simple SP energy calculation."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job1 = extract_job(result, 1)
     parsed = parse_qchem_input(job1)
@@ -296,11 +284,7 @@ def test_mom_job1_simple_sp(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job2_has_read_molecule(qchem_builder, h2o_geometry, minimal_spec):
     """job2 of mom calculation should have $molecule read."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -312,11 +296,7 @@ def test_mom_job2_has_read_molecule(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job2_has_occupied_block(qchem_builder, h2o_geometry, minimal_spec):
     """job2 of mom calculation should have $occupied block with MOM target."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -328,11 +308,7 @@ def test_mom_job2_has_occupied_block(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job2_has_mom_start(qchem_builder, h2o_geometry, minimal_spec):
     """job2 of mom calculation should have MOM_START enabled."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -344,11 +320,7 @@ def test_mom_job2_has_mom_start(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job2_scf_guess_read(qchem_builder, h2o_geometry, minimal_spec):
     """job2 of mom calculation should have SCF_GUESS read."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -359,30 +331,16 @@ def test_mom_job2_scf_guess_read(qchem_builder, h2o_geometry, minimal_spec):
 @pytest.mark.contract
 def test_mom_job2_unrestricted(qchem_builder, h2o_geometry, minimal_spec):
     """job2 of mom calculation should be unrestricted."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=False,  # Even if job1 is restricted (shouldn't happen, but test it)
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
     # This should fail validation - MOM requires unrestricted
-    with pytest.raises(ConfigurationError, match="unrestricted"):
-        qchem_builder.build(spec, h2o_geometry)
+    with pytest.raises(ValidationError, match="unrestricted"):
+        replace(minimal_spec, unrestricted=False).set_mom(transition="HOMO->LUMO")
 
 
 @pytest.mark.contract
 def test_mom_ionization_job2_charge_override(qchem_builder, h2o_geometry, minimal_spec):
     """mom ionization should allow charge override for job2."""
-    spec = replace(
-        minimal_spec,
-        charge=0,
-        spin_multiplicity=1,
-        unrestricted=True,
-        program_options={
-            "run_mom": True,
-            "mom_transition": "HOMO->vac",
-            "mom_job2_charge": 1,  # Ionized
-            "mom_job2_spin_multiplicity": 2,  # Doublet
-        },
+    spec = replace(minimal_spec, charge=0, spin_multiplicity=1, unrestricted=True).set_mom(
+        transition="HOMO->vac", job2_charge=1, job2_spin_multiplicity=2
     )
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
@@ -406,8 +364,7 @@ def test_mom_with_solvation(qchem_builder, h2o_geometry):
         basis_set="6-31g",
         unrestricted=True,
         solvation=SolvationSpec(model="smd", solvent="water"),
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    ).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
 
     assert "@@@" in result
@@ -437,10 +394,7 @@ def test_mom_single_transition(h2o_geometry):
             basis_set="6-31g",
         )
         .set_unrestricted(True)
-        .set_options(
-            run_mom=True,
-            mom_transition="HOMO->LUMO",
-        )
+        .set_mom(transition="HOMO->LUMO")
     )
 
     result = calc.export("qchem", h2o_geometry)
@@ -460,11 +414,7 @@ def test_mom_single_transition(h2o_geometry):
 @pytest.mark.regression
 def test_mom_homo_lumo_occupation_count(qchem_builder, h2o_geometry, minimal_spec):
     """HOMO->LUMO excitation should give correct electron count in $occupied."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    spec = replace(minimal_spec, unrestricted=True).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -495,13 +445,7 @@ def test_mom_ionization_electron_count_decreased(qchem_builder, h2o_geometry):
         level_of_theory="b3lyp",
         basis_set="6-31g",
         unrestricted=True,
-        program_options={
-            "run_mom": True,
-            "mom_transition": "HOMO->vac",
-            "mom_job2_charge": 1,  # Ionized
-            "mom_job2_spin_multiplicity": 2,  # Doublet
-        },
-    )
+    ).set_mom(transition="HOMO->vac", job2_charge=1, job2_spin_multiplicity=2)
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -521,8 +465,7 @@ def test_mom_preserves_other_spec_options(qchem_builder, h2o_geometry):
         basis_set="def2-tzvp",
         n_cores=8,
         unrestricted=True,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    ).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
 
     job1 = extract_job(result, 1)
@@ -555,8 +498,7 @@ def test_mom_job1_no_tddft(qchem_builder, h2o_geometry):
         basis_set="6-31g",
         unrestricted=True,
         tddft=TddftSpec(nroots=5, singlets=True, triplets=False, use_tda=True),
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    ).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job1 = extract_job(result, 1)
     parsed = parse_qchem_input(job1)
@@ -579,8 +521,7 @@ def test_mom_job2_preserves_tddft(qchem_builder, h2o_geometry):
         basis_set="6-31g",
         unrestricted=True,
         tddft=TddftSpec(nroots=5, singlets=True, triplets=False, use_tda=True),
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
+    ).set_mom(transition="HOMO->LUMO")
     result = qchem_builder.build(spec, h2o_geometry)
     job2 = extract_job(result, 2)
     parsed = parse_qchem_input(job2)
@@ -598,13 +539,8 @@ def test_mom_job2_preserves_tddft(qchem_builder, h2o_geometry):
 @pytest.mark.unit
 def test_mom_requires_unrestricted(qchem_builder, h2o_geometry, minimal_spec):
     """MOM requires unrestricted calculation."""
-    spec = replace(
-        minimal_spec,
-        unrestricted=False,
-        program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-    )
-    with pytest.raises(ConfigurationError, match="unrestricted"):
-        qchem_builder.build(spec, h2o_geometry)
+    with pytest.raises(ValidationError, match="unrestricted"):
+        replace(minimal_spec, unrestricted=False).set_mom(transition="HOMO->LUMO")
 
 
 @pytest.mark.unit

--- a/tests/io/qchem/qchem_builders/test_builder_validation.py
+++ b/tests/io/qchem/qchem_builders/test_builder_validation.py
@@ -60,18 +60,18 @@ class TestValidateSpec:
         qchem_builder._validate_spec(spec)  # Should not raise
 
     @pytest.mark.unit
-    def test_mom_requires_unrestricted(self, qchem_builder, minimal_spec):
-        """MOM calculation requires unrestricted=True."""
+    def test_deprecated_run_mom_in_program_options(self, qchem_builder, minimal_spec):
+        """Using program_options['run_mom'] should raise deprecation error."""
         spec = CalculationInput(
             charge=0,
             spin_multiplicity=1,
             task="energy",
             level_of_theory="b3lyp",
             basis_set="6-31g",
-            unrestricted=False,
+            unrestricted=True,
             program_options={"run_mom": True},
         )
-        with pytest.raises(ConfigurationError, match="unrestricted"):
+        with pytest.raises(ConfigurationError, match="deprecated"):
             qchem_builder._validate_spec(spec)
 
     @pytest.mark.unit
@@ -84,8 +84,7 @@ class TestValidateSpec:
             level_of_theory="b3lyp",
             basis_set="6-31g",
             unrestricted=True,
-            program_options={"run_mom": True, "mom_transition": "HOMO->LUMO"},
-        )
+        ).set_mom(transition="HOMO->LUMO")
         qchem_builder._validate_spec(spec)  # Should not raise
 
     @pytest.mark.unit


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-06 00:55:51 UTC

<h3>Greptile Summary</h3>


Refactored MOM (Maximum Overlap Method) configuration from generic `program_options` dict to a dedicated `MomSpec` dataclass with type-safe fluent API.

**Key Changes:**
- Added `MomSpec` dataclass in `src/calcflow/common/input.py` to encapsulate MOM settings (transition, method, job2 charge/multiplicity overrides)
- Replaced `program_options["run_mom"]` pattern with `.set_mom()` fluent API method
- Added validation in `CalculationInput.__post_init__()` to enforce unrestricted calculations and required transition/occupation fields
- Introduced `requires_multiple_jobs` property to cleanly signal multi-job workflows
- Extracted MOM job building logic into dedicated methods (`_build_mom_job1`, `_build_mom_job2`) for better separation of concerns
- Updated all tests to use new API and adjusted exception expectations (`ConfigurationError` → `ValidationError` for validation failures)
- Added deprecation error for legacy `program_options["run_mom"]` to guide users to new API
- Fixed import path in `scripts/input-orca.py` (`calcflow.io.input` → `calcflow.common.input`)

**Architecture Improvements:**
- Better encapsulation: MOM-specific logic now lives in a dedicated container rather than scattered across dict keys
- Type safety: IDE autocomplete and static analysis now work for MOM parameters
- Clearer validation: Requirements (unrestricted, transition spec) enforced at construction time
- Extensibility: `requires_multiple_jobs` pattern allows future multi-job workflows without modifying core builder logic

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Clean refactoring that improves architecture without changing behavior. All existing tests updated to match new API, validation logic strengthened with early checks, and backward compatibility handled via clear deprecation errors. Code follows project conventions (immutable dataclasses, fluent API, comprehensive docstrings) and maintains separation of concerns.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/calcflow/common/input.py | 5/5 | Added new `MomSpec` dataclass and `set_mom()` fluent API method to replace program_options-based MOM configuration, with validation in `__post_init__` and new `requires_multiple_jobs` property |
| src/calcflow/io/qchem/builder.py | 5/5 | Refactored MOM handling from program_options to dedicated `MomSpec` container, extracting job building logic into separate methods (`_build_mom_job1`, `_build_mom_job2`) and adding deprecation error for old `run_mom` option |
| tests/io/qchem/qchem_builders/test_builder_mom.py | 5/5 | Updated all test cases to use new `.set_mom()` API instead of `program_options`, changed expected exception from `ConfigurationError` to `ValidationError` for unrestricted requirement |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CalculationInput
    participant QchemBuilder
    participant MomSpec
    
    User->>CalculationInput: create calc with unrestricted=True
    User->>CalculationInput: .set_mom(transition="HOMO->LUMO")
    CalculationInput->>MomSpec: create MomSpec instance
    CalculationInput->>CalculationInput: __post_init__ validation
    Note over CalculationInput: validates unrestricted=True<br/>validates transition is set
    
    User->>CalculationInput: .export("qchem", geometry)
    CalculationInput->>QchemBuilder: build(spec, geometry)
    QchemBuilder->>QchemBuilder: _validate_spec(spec)
    Note over QchemBuilder: checks spec.mom is not None<br/>rejects deprecated run_mom
    
    QchemBuilder->>QchemBuilder: spec.requires_multiple_jobs?
    Note over QchemBuilder: returns True (mom is set)
    
    QchemBuilder->>QchemBuilder: _build_multi_job_input(spec, geometry)
    QchemBuilder->>QchemBuilder: _build_mom_input(spec, geometry)
    
    QchemBuilder->>QchemBuilder: _build_mom_job1(spec, geometry)
    Note over QchemBuilder: ground state SP calculation<br/>task_override="energy"<br/>generates reference orbitals
    
    QchemBuilder->>QchemBuilder: _build_mom_job2(spec, geometry)
    Note over QchemBuilder: excited state calculation<br/>scf_guess="read"<br/>mom_start=True<br/>molecule read
    
    QchemBuilder->>QchemBuilder: _build_occupied_block(spec, geometry)
    QchemBuilder->>QchemBuilder: _convert_extended_transitions_to_occupations()
    Note over QchemBuilder: parses "HOMO->LUMO"<br/>applies excitation<br/>generates alpha/beta occupation strings
    
    QchemBuilder-->>User: returns two-job input file<br/>separated by @@@
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->