### PR TITLE
tests: test reduced excitation space and gs mom

### DIFF
--- a/tests/io/qchem/qchem_builders/test_builder_mom.py
+++ b/tests/io/qchem/qchem_builders/test_builder_mom.py
@@ -568,6 +568,330 @@ def test_invalid_orbital_notation(qchem_builder):
 
 
 # =============================================================================
+# UNIT TESTS: MOM GROUND_STATE Transition
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_mom_ground_state_transition_even_electrons(qchem_builder, h2o_geometry):
+    """MOM GROUND_STATE transition should produce correct occupation for even electrons."""
+    # H2O has 10 electrons -> 5 alpha, 5 beta (ground state)
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="b3lyp",
+        basis_set="6-31g",
+        unrestricted=True,
+    ).set_mom(transition="GROUND_STATE")
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    job2 = extract_job(result, 2)
+    parsed = parse_qchem_input(job2)
+
+    occupied_block = parsed.blocks.get("occupied", "")
+    lines = [line.strip() for line in occupied_block.split("\n") if line.strip() and not line.strip().startswith("$")]
+
+    # Should have alpha and beta lines
+    assert len(lines) == 2
+    alpha_line = lines[0]
+    beta_line = lines[1]
+
+    # For 10 electrons: alpha = 1:5, beta = 1:5
+    assert alpha_line == "1:5"
+    assert beta_line == "1:5"
+
+
+@pytest.mark.unit
+def test_mom_ground_state_single_electron_pair(qchem_builder):
+    """MOM GROUND_STATE with 2 electrons (1 pair) should format as '1' not '1:1'."""
+    from calcflow.common.results import Atom
+    from calcflow.geometry.static import Geometry
+
+    # H2 molecule has 2 electrons -> 1 alpha, 1 beta
+    h2_geom = Geometry(
+        comment="H2 molecule",
+        atoms=(
+            Atom(symbol="H", x=0.0, y=0.0, z=0.0),
+            Atom(symbol="H", x=0.0, y=0.0, z=0.74),
+        ),
+    )
+
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="b3lyp",
+        basis_set="6-31g",
+        unrestricted=True,
+    ).set_mom(transition="GROUND_STATE")
+
+    result = qchem_builder.build(spec, h2_geom)
+    job2 = extract_job(result, 2)
+    parsed = parse_qchem_input(job2)
+
+    occupied_block = parsed.blocks.get("occupied", "")
+    lines = [line.strip() for line in occupied_block.split("\n") if line.strip() and not line.strip().startswith("$")]
+
+    # For 2 electrons: alpha = 1, beta = 1 (not 1:1)
+    alpha_line = lines[0]
+    beta_line = lines[1]
+
+    assert alpha_line == "1"
+    assert beta_line == "1"
+
+
+# =============================================================================
+# CONTRACT TESTS: MOM GROUND_STATE Validation
+# =============================================================================
+
+
+@pytest.mark.contract
+def test_mom_ground_state_requires_even_electrons(qchem_builder):
+    """MOM GROUND_STATE with odd electrons should raise error."""
+    from calcflow.common.exceptions import ConfigurationError
+    from calcflow.common.results import Atom
+    from calcflow.geometry.static import Geometry
+
+    # OH radical has 9 electrons (odd)
+    oh_geom = Geometry(
+        comment="OH radical",
+        atoms=(
+            Atom(symbol="O", x=0.0, y=0.0, z=0.0),
+            Atom(symbol="H", x=0.0, y=0.0, z=0.96),
+        ),
+    )
+
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=2,  # Doublet
+        task="energy",
+        level_of_theory="b3lyp",
+        basis_set="6-31g",
+        unrestricted=True,
+    ).set_mom(transition="GROUND_STATE")
+
+    with pytest.raises(ConfigurationError, match="GROUND_STATE.*even number of electrons"):
+        qchem_builder.build(spec, oh_geom)
+
+
+@pytest.mark.contract
+def test_mom_ground_state_two_job_structure(qchem_builder, h2o_geometry):
+    """MOM GROUND_STATE should generate proper two-job structure."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="b3lyp",
+        basis_set="6-31g",
+        unrestricted=True,
+    ).set_mom(transition="GROUND_STATE")
+
+    result = qchem_builder.build(spec, h2o_geometry)
+
+    # Verify two-job structure
+    assert_two_job_structure(result)
+
+    # Both jobs should be present
+    job1 = extract_job(result, 1)
+    job2 = extract_job(result, 2)
+
+    assert "$molecule" in job1
+    assert "$molecule" in job2
+    assert_block_present(parse_qchem_input(job2).blocks, "occupied")
+
+
+# =============================================================================
+# INTEGRATION TESTS: MOM GROUND_STATE Workflows
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_mom_ground_state_full_workflow(h2o_geometry):
+    """Full MOM workflow with GROUND_STATE transition."""
+    calc = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="b3lyp",
+            basis_set="6-31g",
+        )
+        .set_unrestricted(True)
+        .set_mom(transition="GROUND_STATE")
+    )
+
+    result = calc.export("qchem", h2o_geometry)
+
+    # Verify structure
+    assert_two_job_structure(result)
+    job2 = extract_job(result, 2)
+    parsed = parse_qchem_input(job2)
+
+    # Verify MOM settings
+    assert_rem_value(parsed.rem_block, "MOM_START", "1")
+    assert_rem_value(parsed.rem_block, "SCF_GUESS", "read")
+    assert_block_present(parsed.blocks, "occupied")
+
+
+# =============================================================================
+# CONTRACT TESTS: MOM with TDDFT and TRNSS
+# =============================================================================
+
+
+@pytest.mark.contract
+def test_mom_with_tddft_trnss_solute_block_in_job2(qchem_builder, h2o_geometry):
+    """MOM + TDDFT + TRNSS should have $solute block in job2 only."""
+    from calcflow.common.input import TddftSpec
+
+    spec = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="cam-b3lyp",
+            basis_set="6-31g",
+            unrestricted=True,
+            tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+        )
+        .set_mom(transition="HOMO->LUMO")
+        .set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7])
+    )
+
+    result = qchem_builder.build(spec, h2o_geometry)
+
+    # Job1 should NOT have $solute block (no TDDFT in job1)
+    job1 = extract_job(result, 1)
+    parsed_job1 = parse_qchem_input(job1)
+    assert_block_not_present(parsed_job1.blocks, "solute")
+
+    # Job2 should have $solute block
+    job2 = extract_job(result, 2)
+    parsed_job2 = parse_qchem_input(job2)
+    assert_block_present(parsed_job2.blocks, "solute")
+
+    # Verify TRNSS keywords in job2
+    assert_rem_value(parsed_job2.rem_block, "TRNSS", True)
+    assert_rem_value(parsed_job2.rem_block, "N_SOL", 5)
+
+
+@pytest.mark.contract
+def test_mom_without_trnss_no_solute_block(qchem_builder, h2o_geometry):
+    """MOM + TDDFT without TRNSS should NOT have $solute block."""
+    from calcflow.common.input import TddftSpec
+
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        unrestricted=True,
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+    ).set_mom(transition="HOMO->LUMO")
+
+    result = qchem_builder.build(spec, h2o_geometry)
+
+    # Neither job should have $solute block
+    job1 = extract_job(result, 1)
+    job2 = extract_job(result, 2)
+
+    parsed_job1 = parse_qchem_input(job1)
+    parsed_job2 = parse_qchem_input(job2)
+
+    assert_block_not_present(parsed_job1.blocks, "solute")
+    assert_block_not_present(parsed_job2.blocks, "solute")
+
+
+# =============================================================================
+# INTEGRATION TESTS: MOM with TDDFT and TRNSS Workflows
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_mom_tddft_trnss_full_workflow(h2o_geometry):
+    """Full MOM workflow with TDDFT and reduced excitation space."""
+    calc = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="cam-b3lyp",
+            basis_set="6-311g(d)",
+        )
+        .set_unrestricted(True)
+        .set_mom(transition="HOMO->LUMO")
+        .set_tddft(nroots=10, singlets=True, triplets=False, use_tda=False)
+        .set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7, 8])
+        .set_cores(16)
+    )
+
+    result = calc.export("qchem", h2o_geometry)
+
+    # Verify two-job structure
+    assert_two_job_structure(result)
+
+    job2 = extract_job(result, 2)
+    parsed_job2 = parse_qchem_input(job2)
+
+    # Verify MOM settings
+    assert_rem_value(parsed_job2.rem_block, "MOM_START", "1")
+    assert_rem_value(parsed_job2.rem_block, "SCF_GUESS", "read")
+
+    # Verify TDDFT settings
+    assert_rem_value(parsed_job2.rem_block, "CIS_N_ROOTS", 10)
+    assert_rem_value(parsed_job2.rem_block, "RPA", True)
+
+    # Verify TRNSS settings
+    assert_rem_value(parsed_job2.rem_block, "TRNSS", True)
+    assert_rem_value(parsed_job2.rem_block, "N_SOL", 6)
+
+    # Verify blocks
+    assert_block_present(parsed_job2.blocks, "occupied")
+    assert_block_present(parsed_job2.blocks, "solute")
+
+
+@pytest.mark.integration
+def test_mom_tddft_trnss_with_solvation(h2o_geometry):
+    """MOM + TDDFT + TRNSS + solvation should work together."""
+    calc = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="cam-b3lyp",
+            basis_set="6-31g",
+        )
+        .set_unrestricted(True)
+        .set_mom(transition="HOMO->LUMO")
+        .set_tddft(nroots=5, singlets=True, triplets=False)
+        .set_solvation("smd", "water")
+        .set_options(reduced_excitation_space_orbitals=[4, 5, 6])
+    )
+
+    result = calc.export("qchem", h2o_geometry)
+
+    # Verify two-job structure
+    assert_two_job_structure(result)
+
+    job1 = extract_job(result, 1)
+    job2 = extract_job(result, 2)
+
+    parsed_job1 = parse_qchem_input(job1)
+    parsed_job2 = parse_qchem_input(job2)
+
+    # Both jobs should have solvation
+    assert "smx" in parsed_job1.blocks
+    assert "smx" in parsed_job2.blocks
+
+    # Only job2 should have TDDFT, TRNSS, and $solute
+    assert_rem_value(parsed_job2.rem_block, "CIS_N_ROOTS", 5)
+    assert_rem_value(parsed_job2.rem_block, "TRNSS", True)
+    assert_block_present(parsed_job2.blocks, "solute")
+    assert_block_present(parsed_job2.blocks, "occupied")
+
+
+# =============================================================================
 # PYTEST FIXTURES
 # =============================================================================
 

--- a/tests/io/qchem/qchem_builders/test_builder_tddft.py
+++ b/tests/io/qchem/qchem_builders/test_builder_tddft.py
@@ -19,6 +19,8 @@ from calcflow.common.exceptions import ValidationError
 from calcflow.common.input import CalculationInput, TddftSpec
 from calcflow.io.qchem.builder import QchemBuilder
 from tests.io.qchem.qchem_builders.conftest import (
+    assert_block_not_present,
+    assert_block_present,
     assert_rem_value,
     parse_qchem_input,
 )
@@ -458,6 +460,244 @@ def test_tddft_negative_nroots_validation():
             basis_set="6-31g",
             tddft=TddftSpec(nroots=-1, singlets=True, triplets=False),
         )
+
+
+# =============================================================================
+# UNIT TESTS: TDDFT with Reduced Excitation Space (TRNSS)
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_tddft_trnss_keywords_set(qchem_builder, h2o_geometry):
+    """TDDFT with reduced excitation space should set TRNSS keywords."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+    ).set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7])
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    assert_rem_value(parsed.rem_block, "TRNSS", True)
+    assert_rem_value(parsed.rem_block, "TRTYPE", 3)
+    assert_rem_value(parsed.rem_block, "N_SOL", 5)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "orbitals,expected_n_sol",
+    [
+        ([3, 4, 5], 3),
+        ([1, 2, 3, 4, 5, 6, 7, 8], 8),
+        ([5], 1),
+        ([2, 3, 4, 5, 6], 5),
+    ],
+)
+def test_tddft_trnss_n_sol_matches_orbital_count(qchem_builder, h2o_geometry, orbitals, expected_n_sol):
+    """N_SOL should match the number of orbitals in reduced excitation space."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+    ).set_options(reduced_excitation_space_orbitals=orbitals)
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    assert_rem_value(parsed.rem_block, "N_SOL", expected_n_sol)
+
+
+# =============================================================================
+# CONTRACT TESTS: TDDFT with TRNSS Structure
+# =============================================================================
+
+
+@pytest.mark.contract
+def test_tddft_trnss_solute_block_present(qchem_builder, h2o_geometry):
+    """TDDFT with reduced excitation space should have $solute block."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+    ).set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7])
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    # Should have $solute block
+    assert_block_present(parsed.blocks, "solute")
+
+    # Check content includes the orbital list
+    solute_block = parsed.blocks.get("solute", "")
+    assert "3 4 5 6 7" in solute_block or "3" in solute_block
+
+
+@pytest.mark.contract
+def test_tddft_trnss_requires_tddft(qchem_builder, h2o_geometry):
+    """Reduced excitation space without TDDFT should raise validation error."""
+    from calcflow.common.exceptions import ConfigurationError
+
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        # No TDDFT spec
+    ).set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7])
+
+    with pytest.raises(ConfigurationError, match="reduced excitation space requires tddft"):
+        qchem_builder.build(spec, h2o_geometry)
+
+
+@pytest.mark.contract
+def test_tddft_trnss_orbital_list_format(qchem_builder, h2o_geometry):
+    """$solute block should format orbital list as space-separated integers."""
+    orbitals = [2, 3, 4, 5, 6, 7, 8]
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=10, singlets=True, triplets=False),
+    ).set_options(reduced_excitation_space_orbitals=orbitals)
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    solute_block = parsed.blocks.get("solute", "")
+    # Check all orbitals are present as strings
+    for orb in orbitals:
+        assert str(orb) in solute_block
+
+
+@pytest.mark.contract
+def test_tddft_without_trnss_no_solute_block(qchem_builder, h2o_geometry):
+    """TDDFT without reduced excitation space should NOT have $solute block."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False),
+    )
+
+    result = qchem_builder.build(spec, h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    # Should NOT have $solute block
+    assert_block_not_present(parsed.blocks, "solute")
+
+
+# =============================================================================
+# INTEGRATION TESTS: TDDFT with TRNSS Workflows
+# =============================================================================
+
+
+@pytest.mark.integration
+def test_tddft_trnss_full_workflow(h2o_geometry):
+    """Full TDDFT workflow with reduced excitation space."""
+    calc = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="cam-b3lyp",
+            basis_set="6-311g(d)",
+        )
+        .set_tddft(nroots=10, singlets=True, triplets=False, use_tda=False)
+        .set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7, 8])
+        .set_cores(16)
+    )
+
+    result = calc.export("qchem", h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    # Verify TDDFT settings
+    assert_rem_value(parsed.rem_block, "CIS_N_ROOTS", 10)
+    assert_rem_value(parsed.rem_block, "CIS_SINGLETS", True)
+    assert_rem_value(parsed.rem_block, "RPA", True)
+
+    # Verify TRNSS settings
+    assert_rem_value(parsed.rem_block, "TRNSS", True)
+    assert_rem_value(parsed.rem_block, "TRTYPE", 3)
+    assert_rem_value(parsed.rem_block, "N_SOL", 6)
+
+    # Verify $solute block
+    assert_block_present(parsed.blocks, "solute")
+
+
+@pytest.mark.integration
+def test_tddft_trnss_with_solvation(h2o_geometry):
+    """TDDFT with reduced excitation space and solvation should work together."""
+    calc = (
+        CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="cam-b3lyp",
+            basis_set="6-31g",
+        )
+        .set_tddft(nroots=5, singlets=True, triplets=False)
+        .set_solvation("smd", "water")
+        .set_options(reduced_excitation_space_orbitals=[4, 5, 6])
+    )
+
+    result = calc.export("qchem", h2o_geometry)
+    parsed = parse_qchem_input(result)
+
+    # Should have TDDFT, TRNSS, solvation, and $solute
+    assert_rem_value(parsed.rem_block, "CIS_N_ROOTS", 5)
+    assert_rem_value(parsed.rem_block, "TRNSS", True)
+    assert "smx" in parsed.blocks
+    assert_block_present(parsed.blocks, "solute")
+
+
+# =============================================================================
+# REGRESSION TESTS: TDDFT with TRNSS Semantic Validation
+# =============================================================================
+
+
+@pytest.mark.regression
+def test_tddft_trnss_complete_output_structure(qchem_builder, h2o_geometry):
+    """TDDFT with TRNSS should have complete and correct output structure."""
+    spec = CalculationInput(
+        charge=0,
+        spin_multiplicity=1,
+        task="energy",
+        level_of_theory="cam-b3lyp",
+        basis_set="6-31g",
+        tddft=TddftSpec(nroots=5, singlets=True, triplets=False, use_tda=True),
+    ).set_options(reduced_excitation_space_orbitals=[3, 4, 5, 6, 7])
+
+    result = qchem_builder.build(spec, h2o_geometry)
+
+    # Should be single job (not two-job structure)
+    assert "@@@" not in result
+
+    parsed = parse_qchem_input(result)
+
+    # All required blocks present
+    assert "$molecule" in parsed.molecule_block
+    assert "$rem" in parsed.rem_block
+    assert_block_present(parsed.blocks, "solute")
+
+    # All TRNSS keywords present
+    assert_rem_value(parsed.rem_block, "TRNSS", True)
+    assert_rem_value(parsed.rem_block, "TRTYPE", 3)
+    assert_rem_value(parsed.rem_block, "N_SOL", 5)
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-06 01:07:40 UTC

<h3>Greptile Summary</h3>


Added comprehensive test coverage for two new features: MOM `GROUND_STATE` transition and TDDFT with reduced excitation space (TRNSS).

**Key additions:**

**`test_builder_mom.py` (324 lines)**
- Unit tests for `GROUND_STATE` transition logic (even electron validation, correct occupation formatting)
- Contract tests for `GROUND_STATE` validation and two-job structure
- Integration tests for `GROUND_STATE` workflow
- Contract tests for MOM+TDDFT+TRNSS interaction (verifies `$solute` block placement)
- Integration tests for combined MOM+TDDFT+TRNSS workflows with solvation

**`test_builder_tddft.py` (244 lines)**
- Unit tests for TRNSS keyword generation (`TRNSS`, `TRTYPE`, `N_SOL`)
- Contract tests for `$solute` block presence and format
- Contract test validating TRNSS requires TDDFT enabled
- Integration tests for TRNSS with solvation
- Regression test for complete output structure

All tests follow the project's testing philosophy with proper markers (`@pytest.mark.unit`, `@pytest.mark.contract`, `@pytest.mark.integration`, `@pytest.mark.regression`) and clear separation of concerns.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-structured test additions with no logic changes to production code
- Tests are comprehensive, follow project conventions, use proper markers, and only add coverage for existing features
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/io/qchem/qchem_builders/test_builder_mom.py | 5/5 | Added comprehensive test coverage for MOM GROUND_STATE transition and MOM+TDDFT+TRNSS interaction |
| tests/io/qchem/qchem_builders/test_builder_tddft.py | 5/5 | Added comprehensive test coverage for TDDFT with reduced excitation space (TRNSS) feature |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Builder as QchemBuilder
    participant Spec as CalculationInput
    participant Geometry as Geometry

    Note over Test,Geometry: TDDFT with Reduced Excitation Space (TRNSS)
    Test->>Spec: set_tddft(nroots, singlets, triplets)
    Test->>Spec: set_options(reduced_excitation_space_orbitals)
    Test->>Builder: build(spec, geometry)
    Builder->>Builder: _validate_spec()
    Note right of Builder: Validates TRNSS requires TDDFT
    Builder->>Builder: _build_single_job_input()
    Builder->>Builder: _build_rem()
    Note right of Builder: Sets TRNSS=True, TRTYPE=3, N_SOL=len(orbitals)
    Builder->>Builder: _build_solute()
    Note right of Builder: Creates $solute block with orbital list
    Builder-->>Test: Q-Chem input with TRNSS

    Note over Test,Geometry: MOM GROUND_STATE Transition
    Test->>Spec: set_mom(transition="GROUND_STATE")
    Test->>Builder: build(spec, geometry)
    Builder->>Builder: _validate_spec()
    Builder->>Builder: _build_multi_job_input()
    Builder->>Builder: _build_mom_input()
    Builder->>Geometry: total_nuclear_charge
    Builder->>Builder: _build_occupied_block()
    Note right of Builder: Validates even electrons<br/>Calculates n_occ = total_electrons // 2<br/>Formats as "1:n_occ" or "1"
    Builder->>Builder: _build_mom_job1()
    Note right of Builder: Ground state reference
    Builder->>Builder: _build_mom_job2()
    Note right of Builder: With $occupied block
    Builder-->>Test: Two-job Q-Chem input

    Note over Test,Geometry: MOM + TDDFT + TRNSS Combination
    Test->>Spec: set_mom(transition="HOMO->LUMO")
    Test->>Spec: set_tddft(nroots, singlets, triplets)
    Test->>Spec: set_options(reduced_excitation_space_orbitals)
    Test->>Builder: build(spec, geometry)
    Builder->>Builder: _build_mom_input()
    Builder->>Builder: _build_mom_job1()
    Note right of Builder: No TDDFT, no $solute
    Builder->>Builder: _build_mom_job2()
    Builder->>Builder: _build_rem() with TDDFT
    Note right of Builder: Sets TRNSS keywords
    Builder->>Builder: _build_occupied_block()
    Builder->>Builder: _build_solute()
    Note right of Builder: $solute only in job2
    Builder-->>Test: Two-job input with MOM+TDDFT+TRNSS
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->