### PR TITLE
REF: tighten spin types and fix zip strict=False

### DIFF
--- a/src/calcflow/common/results.py
+++ b/src/calcflow/common/results.py
@@ -25,7 +25,7 @@ from types import UnionType
 from typing import Any, Literal, TypeAliasType, TypeVar, Union, get_args, get_origin
 
 from calcflow.common.exceptions import ValidationError
-from calcflow.common.types import Matrix3x3
+from calcflow.common.types import AdcSpin, Matrix3x3
 from calcflow.constants.ptable import ELEMENT_DATA
 
 # cache version at module load to avoid repeated filesystem lookups
@@ -92,7 +92,7 @@ class FrozenModel:
             if len(args) == 2 and args[1] is Ellipsis:
                 return tuple(FrozenModel._convert_value(item, args[0]) for item in value)
             return tuple(
-                FrozenModel._convert_value(item, item_type) for item, item_type in zip(value, args, strict=False)
+                FrozenModel._convert_value(item, item_type) for item, item_type in zip(value, args, strict=True)
             )
 
         if origin in (dict, Mapping) and isinstance(value, dict):
@@ -527,7 +527,7 @@ class AdcAmplitude(FrozenModel):
     occ_i: int  # occupied orbital index (1-based as in output)
     vir_a: int  # virtual orbital index (1-based as in output)
     amplitude: float
-    spin: str | None = None  # "A" (alpha) or "B" (beta) for the occ_i/vir_a pair
+    spin: AdcSpin | None = None  # "A" (alpha) or "B" (beta) for the occ_i/vir_a pair
     occ_j: int | None = None  # second occupied index for 2p2h configurations
     vir_b: int | None = None  # second virtual index for 2p2h configurations
 

--- a/src/calcflow/common/types.py
+++ b/src/calcflow/common/types.py
@@ -1,6 +1,7 @@
 """common, non-pydantic type aliases used throughout the library."""
 
 from collections.abc import Iterator
+from typing import Literal
 
 # an iterator that yields lines from a file or text block.
 # used extensively by all parsers.
@@ -13,3 +14,9 @@ type AtomCoords = tuple[str, Coord3d]
 # a 3x3 matrix stored as a tuple of three row tuples.
 # used for two-photon absorption matrices and similar tensor quantities.
 type Matrix3x3 = tuple[Coord3d, Coord3d, Coord3d]
+
+# spin channel discriminant used in parsers and the job builder.
+type SpinChannel = Literal["alpha", "beta"]
+
+# single-character ADC amplitude spin label as it appears in Q-Chem output.
+type AdcSpin = Literal["A", "B"]

--- a/src/calcflow/io/qchem/blocks/adc/excited_states.py
+++ b/src/calcflow/io/qchem/blocks/adc/excited_states.py
@@ -35,6 +35,7 @@ from calcflow.common.results import (
     NTOContribution,
     TwoPhotonAbsorption,
 )
+from calcflow.common.types import SpinChannel
 from calcflow.io.core import BlockParser, ParseState
 
 logger = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ class AdcExcitedStatesParser(BlockParser):
         in_amplitudes = False
         nto_alpha: list[NTOContribution] = []
         nto_beta: list[NTOContribution] = []
-        current_nto_spin: str | None = None  # "alpha" or "beta"
+        current_nto_spin: SpinChannel | None = None
         in_nto_section = False
 
         while True:

--- a/src/calcflow/io/qchem/blocks/orbitals.py
+++ b/src/calcflow/io/qchem/blocks/orbitals.py
@@ -11,6 +11,7 @@ from collections.abc import Iterator
 
 from calcflow.common.exceptions import ParsingError
 from calcflow.common.results import Orbital, OrbitalsSet
+from calcflow.common.types import SpinChannel
 from calcflow.io.state import ParseState
 from calcflow.utils import logger
 
@@ -53,7 +54,7 @@ class OrbitalsParser:
         beta_virtual_energies: list[float] = []
 
         # State machine variables
-        current_spin: str | None = None  # "alpha" or "beta"
+        current_spin: SpinChannel | None = None
         current_section: str | None = None  # "occupied" or "virtual"
 
         # Skip the initial separator line

--- a/src/calcflow/io/qchem/blocks/tddft/nto.py
+++ b/src/calcflow/io/qchem/blocks/tddft/nto.py
@@ -13,8 +13,10 @@ Format:
 
 import re
 from collections.abc import Iterator
+from typing import cast
 
 from calcflow.common.results import NTOContribution, NTOStateAnalysis
+from calcflow.common.types import SpinChannel
 from calcflow.io.state import ParseState
 from calcflow.utils import logger
 
@@ -67,7 +69,7 @@ class NTOParser:
 
         nto_states: list[NTOStateAnalysis] = []
         current_state: dict | None = None
-        current_spin: str | None = None  # Track 'alpha' or 'beta' for UKS
+        current_spin: SpinChannel | None = None
         last_state_number = 0  # Track expected state sequence
 
         for line in iterator:
@@ -142,7 +144,7 @@ class NTOParser:
             if current_state.get("is_uks"):
                 spin_match = SPIN_SECTION_PAT.search(line)
                 if spin_match:
-                    current_spin = spin_match.group(1).lower()
+                    current_spin = cast("SpinChannel", spin_match.group(1).lower())
                     continue
 
             # --- Parse NTO contribution ---

--- a/src/calcflow/io/qchem/builder.py
+++ b/src/calcflow/io/qchem/builder.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from calcflow.common.exceptions import ConfigurationError, NotSupportedError, ValidationError
+from calcflow.common.types import SpinChannel
 from calcflow.geometry.static import Geometry
 
 if TYPE_CHECKING:
@@ -322,7 +323,9 @@ class QchemBuilder:
         else:  # LUMO
             return initial_homo + 1 + offset if operator == "+" else initial_homo + 1
 
-    def _apply_ionization(self, source_idx: int, spin: str | None, alpha_occ: set[int], beta_occ: set[int]) -> None:
+    def _apply_ionization(
+        self, source_idx: int, spin: SpinChannel | None, alpha_occ: set[int], beta_occ: set[int]
+    ) -> None:
         """
         removes an electron from the specified orbital for ionization transitions (e.g., "HOMO->vac").
 
@@ -359,9 +362,9 @@ class QchemBuilder:
     def _apply_excitation(
         self,
         source_idx: int,
-        source_spin: str | None,
+        source_spin: SpinChannel | None,
         target_idx: int,
-        target_spin: str | None,
+        target_spin: SpinChannel | None,
         alpha_occ: set[int],
         beta_occ: set[int],
         initial_homo: int,
@@ -386,14 +389,14 @@ class QchemBuilder:
         else:
             beta_occ.add(target_idx)
 
-    def _parse_spin_specification(self, orbital_spec: str) -> tuple[str, str | None]:
+    def _parse_spin_specification(self, orbital_spec: str) -> tuple[str, SpinChannel | None]:
         """parses '5(beta)' into ('5', 'beta')."""
         match = re.match(r"^(.+?)\((\w+)\)$", orbital_spec.strip(), re.IGNORECASE)
         if match:
             orb, spin = match.group(1).strip(), match.group(2).lower()
             if spin not in ("alpha", "beta"):
                 raise ValidationError(f"invalid spin '{spin}'. must be 'alpha' or 'beta'.")
-            return orb, spin
+            return orb, cast("SpinChannel", spin)
         return orbital_spec.strip(), None
 
     def _format_occupation_set(self, occupied: set[int]) -> str:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens type annotations across the Q-Chem parser and job builder by replacing broad `str` annotations with two new `Literal` type aliases (`SpinChannel` for `"alpha"/"beta"` and `AdcSpin` for `"A"/"B"`), and fixes a subtle serialization bug where `zip(…, strict=False)` silently truncated fixed-length tuples during `FrozenModel` deserialization.

Key changes:
- **`types.py`**: Adds `SpinChannel = Literal["alpha", "beta"]` and `AdcSpin = Literal["A", "B"]` as explicit discriminants.
- **`results.py`**: `zip(strict=False)` → `zip(strict=True)` for fixed-length tuple conversion — surfaces length mismatches instead of silently discarding data. `AdcAmplitude.spin` narrowed from `str | None` to `AdcSpin | None`.
- **`tddft/nto.py` and `builder.py`**: Correct use of `cast("SpinChannel", …)` after regex extraction / explicit validation.
- **`adc/excited_states.py`**: Annotation of `current_nto_spin` narrowed, but the `AdcAmplitude` construction site (line 314 / 320) is missing the corresponding `cast("AdcSpin", spin_i)`, leaving an unresolved `str → Literal["A","B"]` assignment that will fail under strict type checking.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one small follow-up: add `cast("AdcSpin", ...)` in `excited_states.py` for type-checker consistency.
- All runtime behaviour is correct — `strict=True` is the right semantic for fixed-length tuples, and the `Literal` aliases match what the regex actually produces. The only gap is a missing `cast` in `excited_states.py` that makes the PR's own type tightening incomplete and will trigger strict-mode type errors, but it causes no runtime issue.
- src/calcflow/io/qchem/blocks/adc/excited_states.py — missing `cast("AdcSpin", spin_i)` on lines 314 and 320.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/calcflow/common/results.py | Changed `zip(..., strict=False)` to `strict=True` for fixed-length tuple deserialization — correct behaviour since value length must match the type's arg count. Also narrowed `AdcAmplitude.spin` from `str | None` to `AdcSpin | None`. |
| src/calcflow/common/types.py | Adds two new Literal type aliases — `SpinChannel` and `AdcSpin` — used to replace loose `str` annotations throughout parsers and the builder. |
| src/calcflow/io/qchem/blocks/adc/excited_states.py | Adopts `SpinChannel` for `current_nto_spin` annotation, but is missing `cast("AdcSpin", ...)` when constructing `AdcAmplitude` with the regex-extracted `spin_i` string — inconsistent with the rest of the PR and will fail strict type checks. |
| src/calcflow/io/qchem/blocks/orbitals.py | Straightforward annotation tightening: `current_spin: str | None` → `current_spin: SpinChannel | None`. No logic changes. |
| src/calcflow/io/qchem/blocks/tddft/nto.py | Narrows `current_spin` annotation and correctly adds `cast("SpinChannel", ...)` when assigning from the regex match, which is safe because `SPIN_SECTION_PAT` only captures "Alpha"/"Beta". |
| src/calcflow/io/qchem/builder.py | Method signatures for `_apply_ionization`, `_apply_excitation`, and `_parse_spin_specification` tightened from `str | None` to `SpinChannel | None`. The `cast` in `_parse_spin_specification` is safe due to prior explicit validation. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FrozenModel.from_dict(data)"] --> B["_convert_value(value, field_type)"]
    B --> C{TypeAliasType?}
    C -->|yes| D["Unwrap __value__\ne.g. AdcSpin → Literal['A','B']"]
    D --> B
    C -->|no| E{Optional / Union?}
    E -->|yes| F["Unwrap inner type\ne.g. SpinChannel | None → SpinChannel"]
    F --> B
    E -->|no| G{origin is tuple?}
    G -->|"len(args)==2 and args[1] is Ellipsis\n(variable-length)"| H["zip(value, args[0]) — no strict"]
    G -->|"fixed-length tuple\ne.g. tuple[float,float,float]"| I["zip(value, args, strict=True)\n✅ raises ValueError if lengths differ"]
    G -->|no| J["list / dict / scalar …"]
    I --> K["tuple(_convert_value per element)"]
    H --> K
    J --> L["return value / coerce"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/calcflow/io/qchem/blocks/adc/excited_states.py`, line 314-324 ([link](https://github.com/ischemist/project-prometheus/blob/37697e5f3552782549d41078867d16f2370b66ca/src/calcflow/io/qchem/blocks/adc/excited_states.py#L314-L324)) 

   **Missing `cast` for `AdcSpin`**

   `orbs[0][1]` is typed as `str` by the regex `findall` return type, but it is passed directly to `AdcAmplitude(spin=...)` which now expects `AdcSpin | None` (i.e. `Literal["A", "B"] | None`). This is inconsistent with the pattern used everywhere else in this PR (e.g. `nto.py` line 147 uses `cast("SpinChannel", ...)`) and will be flagged as a type error by strict checkers.

   The regex `(A|B)` guarantees the value is always `"A"` or `"B"` at runtime, so a `cast` is the correct fix:

   

   You will also need to add `from typing import cast` and `from calcflow.common.types import AdcSpin` to the imports in this file.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 37697e5</sub>

<!-- /greptile_comment -->