### PR TITLE
ref: remove to/from dict dups

### DIFF
--- a/src/calcflow/common/input.py
+++ b/src/calcflow/common/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass, field, replace
 from importlib.metadata import version
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 
 from calcflow.common.exceptions import ConfigurationError, ValidationError
 from calcflow.geometry.static import Geometry
@@ -11,6 +11,7 @@ from calcflow.io.orca.builder import OrcaBuilder
 from calcflow.io.qchem.builder import QchemBuilder
 
 T_CalculationInput = TypeVar("T_CalculationInput", bound="CalculationInput")
+T_SpecSerializable = TypeVar("T_SpecSerializable", bound="_SpecSerializable")
 type TASK_TYPES = Literal["energy", "geometry", "frequency"]
 
 # cache version at module load to avoid repeated filesystem lookups
@@ -24,8 +25,21 @@ BUILDERS = {"orca": OrcaBuilder(), "qchem": QchemBuilder()}
 # that feature is simply not requested.
 
 
+class _SpecSerializable:
+    """shared strict serialization helpers for component specs."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """serializes to a dictionary."""
+        return asdict(cast(Any, self))
+
+    @classmethod
+    def from_dict(cls: type[T_SpecSerializable], data: dict[str, Any]) -> T_SpecSerializable:
+        """deserializes from a dictionary."""
+        return cls(**data)
+
+
 @dataclass(frozen=True)
-class TddftSpec:
+class TddftSpec(_SpecSerializable):
     """specification for a time-dependent dft calculation."""
 
     nroots: int
@@ -34,18 +48,9 @@ class TddftSpec:
     use_tda: bool = True  # Tamm-Dancoff Approximation is a common choice
     state_to_optimize: int | None = None  # for geometry optimization of an excited state
 
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> TddftSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
-
 
 @dataclass(frozen=True)
-class SolvationSpec:
+class SolvationSpec(_SpecSerializable):
     """specification for an implicit solvation model."""
 
     model: str  # e.g., 'smd', 'cpcm'
@@ -53,18 +58,9 @@ class SolvationSpec:
     dielectric: float | None = None  # static dielectric constant (overrides named solvent for pcm)
     optical_dielectric: float | None = None  # high-frequency dielectric constant
 
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SolvationSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
-
 
 @dataclass(frozen=True)
-class ChargesSpec:
+class ChargesSpec(_SpecSerializable):
     """which charge partitioning schemes to compute."""
 
     mulliken: bool = True
@@ -83,53 +79,26 @@ class ChargesSpec:
         if self.hirshiter and not self.hirshfeld:
             object.__setattr__(self, "hirshfeld", True)
 
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ChargesSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
-
 
 @dataclass(frozen=True)
-class ScfSpec:
+class ScfSpec(_SpecSerializable):
     """scf convergence parameters."""
 
     algorithm: str = "diis"
     max_cycles: int = 100
     convergence: int = 8  # threshold exponent: scf converges when error < 10^-N
 
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ScfSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
-
 
 @dataclass(frozen=True)
-class OptimizationSpec:
+class OptimizationSpec(_SpecSerializable):
     """specification for geometry optimization tasks."""
 
     calc_hess_initial: bool = False
     recalc_hess_freq: int | None = None
 
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> OptimizationSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
-
 
 @dataclass(frozen=True)
-class MomSpec:
+class MomSpec(_SpecSerializable):
     """
     specification for maximum overlap method (mom) calculations.
 
@@ -158,15 +127,6 @@ class MomSpec:
     # manual override for advanced users (bypasses symbolic transition parsing)
     alpha_occupation: str | None = None
     beta_occupation: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        """serializes to a dictionary."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> MomSpec:
-        """deserializes from a dictionary."""
-        return cls(**data)
 
 
 # --- Main Calculation Specification ---

--- a/tests/common/test_input_serialization.py
+++ b/tests/common/test_input_serialization.py
@@ -236,6 +236,27 @@ class TestMomSpecSerialization:
         assert spec.beta_occupation == "1-4"
 
 
+@pytest.mark.unit
+class TestSpecFromDictStrictness:
+    @pytest.mark.parametrize(
+        ("spec_cls", "valid_data"),
+        [
+            (TddftSpec, {"nroots": 10}),
+            (SolvationSpec, {"model": "smd", "solvent": "water"}),
+            (ChargesSpec, {"mulliken": True}),
+            (ScfSpec, {"algorithm": "diis"}),
+            (OptimizationSpec, {"calc_hess_initial": True}),
+            (MomSpec, {"transition": "HOMO->LUMO"}),
+        ],
+    )
+    def test_from_dict_raises_on_unknown_key(self, spec_cls, valid_data):
+        """spec from_dict remains strict and rejects unknown keys."""
+        data_with_unknown = {**valid_data, "unknown_key": "unexpected"}
+
+        with pytest.raises(TypeError, match="unknown_key"):
+            spec_cls.from_dict(data_with_unknown)
+
+
 # --- contract tests: roundtrip fidelity ---
 
 
@@ -273,6 +294,58 @@ class TestSpecRoundtrip:
 
 @pytest.mark.contract
 class TestCalculationInputSerialization:
+    def test_to_dict_includes_calcflow_version(self):
+        calc = CalculationInput(
+            charge=0,
+            spin_multiplicity=1,
+            task="energy",
+            level_of_theory="b3lyp",
+            basis_set="6-31g*",
+        )
+
+        data = calc.to_dict()
+        assert "calcflow_version" in data
+        assert isinstance(data["calcflow_version"], str)
+        assert data["calcflow_version"]
+
+    def test_from_dict_ignores_calcflow_version(self):
+        data = {
+            "charge": 0,
+            "spin_multiplicity": 1,
+            "task": "energy",
+            "level_of_theory": "b3lyp",
+            "basis_set": "6-31g*",
+            "unrestricted": False,
+            "n_cores": 1,
+            "memory_per_core_mb": 4000,
+            "tddft": None,
+            "solvation": None,
+            "optimization": None,
+            "mom": None,
+            "charges": None,
+            "scf": None,
+            "frequency_after_optimization": False,
+            "program_options": {},
+            "calcflow_version": "0.0.0-test",
+        }
+
+        calc = CalculationInput.from_dict(data)
+        assert calc.charge == 0
+        assert calc.task == "energy"
+
+    def test_from_dict_raises_on_unknown_top_level_key(self):
+        data = {
+            "charge": 0,
+            "spin_multiplicity": 1,
+            "task": "energy",
+            "level_of_theory": "b3lyp",
+            "basis_set": "6-31g*",
+            "unknown_key": "unexpected",
+        }
+
+        with pytest.raises(TypeError, match="unknown_key"):
+            CalculationInput.from_dict(data)
+
     def test_to_dict_minimal(self):
         calc = CalculationInput(
             charge=0,

--- a/tests/common/test_results_serialization.py
+++ b/tests/common/test_results_serialization.py
@@ -67,6 +67,10 @@ class TestAtomSerialization:
         reconstructed = Atom.from_dict(atom.to_dict())
         assert reconstructed == atom
 
+    def test_from_dict_ignores_unknown_keys(self):
+        atom = Atom.from_dict({"symbol": "H", "x": 0.0, "y": 0.0, "z": 0.96, "unknown_key": "ignored"})
+        assert atom == Atom(symbol="H", x=0.0, y=0.0, z=0.96)
+
 
 @pytest.mark.unit
 class TestOrbitalSerialization:
@@ -396,6 +400,44 @@ class TestAdcResultsSerialization:
 
 @pytest.mark.contract
 class TestCalculationResultSerialization:
+    def test_to_dict_includes_calcflow_version(self):
+        result = CalculationResult(
+            termination_status="NORMAL",
+            metadata=CalculationMetadata(software_name="ORCA", software_version="5.0.3"),
+            raw_output="output",
+            final_energy=-75.313506,
+        )
+
+        data = result.to_dict()
+        assert "calcflow_version" in data
+        assert isinstance(data["calcflow_version"], str)
+        assert data["calcflow_version"]
+
+    def test_from_dict_ignores_calcflow_version(self):
+        data = {
+            "termination_status": "NORMAL",
+            "metadata": {"software_name": "ORCA", "software_version": "5.0.3"},
+            "final_energy": -75.313506,
+            "nuclear_repulsion_energy": None,
+            "input_geometry": None,
+            "final_geometry": None,
+            "scf": None,
+            "orbitals": None,
+            "multipole": None,
+            "smd": None,
+            "tddft": None,
+            "adc": None,
+            "dispersion": None,
+            "timing": None,
+            "atomic_charges": [],
+            "program_specific": {},
+            "calcflow_version": "0.0.0-test",
+        }
+
+        result = CalculationResult.from_dict(data)
+        assert result.termination_status == "NORMAL"
+        assert result.raw_output == ""
+
     def test_to_dict_excludes_raw_output(self):
         result = CalculationResult(
             termination_status="NORMAL",
@@ -566,9 +608,10 @@ class TestRealParsedOutputSerialization:
         assert reconstructed.metadata.software_name == original_result.metadata.software_name
 
         # verify SCF data preserved
-        if original_result.scf:
-            assert reconstructed.scf.converged == original_result.scf.converged
-            assert reconstructed.scf.energy == original_result.scf.energy
+        assert original_result.scf is not None
+        assert reconstructed.scf is not None
+        assert reconstructed.scf.converged == original_result.scf.converged
+        assert reconstructed.scf.energy == original_result.scf.energy
 
         # verify raw_output was excluded
         assert "raw_output" not in json.loads(json_str)
@@ -588,16 +631,17 @@ class TestRealParsedOutputSerialization:
         reconstructed = CalculationResult.from_json(json_str)
 
         # verify TDDFT data preserved
-        if original_result.tddft and original_result.tddft.tddft_states:
-            assert reconstructed.tddft is not None
-            assert len(reconstructed.tddft.tddft_states) == len(original_result.tddft.tddft_states)
+        assert original_result.tddft is not None
+        assert original_result.tddft.tddft_states
+        assert reconstructed.tddft is not None
+        assert len(reconstructed.tddft.tddft_states) == len(original_result.tddft.tddft_states)
 
-            # check first excited state
-            orig_state = original_result.tddft.tddft_states[0]
-            recon_state = reconstructed.tddft.tddft_states[0]
-            assert recon_state.state_number == orig_state.state_number
-            assert recon_state.excitation_energy_ev == orig_state.excitation_energy_ev
-            assert recon_state.multiplicity == orig_state.multiplicity
+        # check first excited state
+        orig_state = original_result.tddft.tddft_states[0]
+        recon_state = reconstructed.tddft.tddft_states[0]
+        assert recon_state.state_number == orig_state.state_number
+        assert recon_state.excitation_energy_ev == orig_state.excitation_energy_ev
+        assert recon_state.multiplicity == orig_state.multiplicity
 
     def test_qchem_adc_roundtrip(self, test_data_dir):
         """test serialization of Q-Chem ADC output with nested tuple fields."""


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates copy-pasted `to_dict` / `from_dict` boilerplate across six spec dataclasses (`TddftSpec`, `SolvationSpec`, `ChargesSpec`, `ScfSpec`, `OptimizationSpec`, `MomSpec`) by introducing a shared `_SpecSerializable` mixin. It also strengthens the test suite by adding strictness tests, `calcflow_version` round-trip coverage, and converting weak conditional guards to hard `assert` statements in the results serialisation tests.

**Key changes:**
- `_SpecSerializable` base class centralises `to_dict()` (via `asdict(cast(Any, self))`) and `from_dict()` (via `cls(**data)`), which is strict — unknown keys raise `TypeError`.
- `T_SpecSerializable` TypeVar added at module level to properly type the `from_dict` classmethod return.
- `TestSpecFromDictStrictness` parametrised test documents and enforces that all spec classes reject unknown keys.
- New `TestCalculationInputSerialization` tests cover `calcflow_version` stripping and top-level unknown-key rejection.
- New `TestCalculationResultSerialization` tests verify `calcflow_version` inclusion/stripping in results.
- `test_from_dict_ignores_unknown_keys` for `Atom` intentionally documents the **opposite** behaviour (lenient deserialization) from the spec classes — this asymmetry is not explained in any comment and may confuse future contributors.
- `if original_result.scf:` guards replaced with explicit `assert ... is not None` statements, making roundtrip tests fail loudly when test data doesn't contain expected fields.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the refactoring is correct at runtime and meaningfully improves the test suite.
- All six spec dataclasses are frozen dataclasses, so `asdict(cast(Any, self))` is correct at runtime and the shared `from_dict` preserves existing strict behaviour. The only notable concern is that `cast(Any, self)` removes static-analysis protection for future non-dataclass subclasses, but this is a style/robustness issue rather than a current bug. Test improvements are strictly additive and make the suite more reliable.
- Minor attention to `src/calcflow/common/input.py` — the `cast(Any, self)` pattern in `_SpecSerializable.to_dict()` is a future maintenance footgun if the class hierarchy evolves.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/calcflow/common/input.py | Introduces `_SpecSerializable` base class to de-duplicate `to_dict`/`from_dict` methods across 6 spec dataclasses; uses `cast(Any, self)` to satisfy type-checker for `asdict()`. Logic is sound at runtime since all concrete subclasses are frozen dataclasses, but the cast silently removes type-checking protection for potential non-dataclass subclasses. |
| tests/common/test_input_serialization.py | Adds `TestSpecFromDictStrictness` to document that all `_SpecSerializable.from_dict()` implementations reject unknown keys, plus new `TestCalculationInputSerialization` tests covering `calcflow_version` round-trip and unknown-key rejection at the top level. Tests are well-structured and use parametrize effectively. |
| tests/common/test_results_serialization.py | Adds `test_from_dict_ignores_unknown_keys` for `Atom` (documenting lenient behaviour), adds `CalculationResult` serialization tests, and upgrades weak conditional guards (`if original_result.scf`) to hard assertions (`assert original_result.scf is not None`), making the serialization roundtrip tests more reliable. |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class _SpecSerializable {
        +to_dict() dict
        +from_dict(data) T_SpecSerializable
    }
    class TddftSpec {
        +nroots: int
        +singlets: bool
        +triplets: bool
        +use_tda: bool
        +state_to_optimize: int | None
    }
    class SolvationSpec {
        +model: str
        +solvent: str
        +dielectric: float | None
        +optical_dielectric: float | None
    }
    class ChargesSpec {
        +mulliken: bool
        +hirshfeld: bool
        +cm5: bool
        +hirshiter: bool
        +hirshiter_thresh: int
        +__post_init__()
    }
    class ScfSpec {
        +algorithm: str
        +max_cycles: int
        +convergence: int
    }
    class OptimizationSpec {
        +calc_hess_initial: bool
        +recalc_hess_freq: int | None
    }
    class MomSpec {
        +transition: str
        +method: str
        +job2_charge: int | None
        +job2_spin_multiplicity: int | None
        +alpha_occupation: str | None
        +beta_occupation: str | None
    }
    class CalculationInput {
        +charge: int
        +spin_multiplicity: int
        +task: TASK_TYPES
        +tddft: TddftSpec | None
        +solvation: SolvationSpec | None
        +optimization: OptimizationSpec | None
        +mom: MomSpec | None
        +charges: ChargesSpec | None
        +scf: ScfSpec | None
        +to_dict() dict
        +from_dict(data) CalculationInput
    }
    _SpecSerializable <|-- TddftSpec
    _SpecSerializable <|-- SolvationSpec
    _SpecSerializable <|-- ChargesSpec
    _SpecSerializable <|-- ScfSpec
    _SpecSerializable <|-- OptimizationSpec
    _SpecSerializable <|-- MomSpec
    CalculationInput o-- TddftSpec
    CalculationInput o-- SolvationSpec
    CalculationInput o-- ChargesSpec
    CalculationInput o-- ScfSpec
    CalculationInput o-- OptimizationSpec
    CalculationInput o-- MomSpec
```

<sub>Last reviewed commit: 49684c0</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->