### PR TITLE
feat: specify schema version in dumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,10 @@
 - **ParseState contract**: single mutable scratchpad, parsers write results to it, control flags prevent duplicate parsing, `buffered_line` for over-reading
 - **Adding parser**: (1) identify block markers, (2) create pydantic model in `common/models.py`, (3) implement BlockParser with `matches()`/`parse()`, (4) register in parser_registry, (5) write contract test
 - **Critical**: parsers must set completion flags (e.g., `state.parsed_scf = True`), handle `buffered_line` if over-reading, raise ParsingError for critical issues
+
+## Schema Versioning (see docs/schema-versioning.md)
+- **Two version fields** in serialized dumps: `calcflow_version` (semver, provenance) and `schema_version` (integer, compatibility)
+- **Independent versions**: `RESULT_SCHEMA_VERSION` in `results.py`, `INPUT_SCHEMA_VERSION` in `input.py`
+- **Bump schema_version** when: renaming/removing/restructuring fields, changing field types, adding required fields
+- **Don't bump** when: adding optional fields with defaults, fixing parser bugs, changing default values
+- **Migrations**: sequential steps in `_migrate()` — v1→v2, then v2→v3, never skip

--- a/src/calcflow/common/input.py
+++ b/src/calcflow/common/input.py
@@ -509,7 +509,15 @@ class CalculationInput:
             if from_version < 3:
                 data = _migrate_input_v2_to_v3(data)
         """
-        if from_version < INPUT_SCHEMA_VERSION:
+        if from_version > INPUT_SCHEMA_VERSION:
+            logger.warning(
+                "CalculationInput dump was created with schema version %d, "
+                "but this code only understands version %d. "
+                "Some fields may be missing or misinterpreted.",
+                from_version,
+                INPUT_SCHEMA_VERSION,
+            )
+        elif from_version < INPUT_SCHEMA_VERSION:
             logger.warning(
                 "Migrating CalculationInput from schema version %d to %d.",
                 from_version,

--- a/src/calcflow/common/results.py
+++ b/src/calcflow/common/results.py
@@ -700,7 +700,15 @@ class CalculationResult(FrozenModel):
             if from_version < 3:
                 data = _migrate_result_v2_to_v3(data)
         """
-        if from_version < RESULT_SCHEMA_VERSION:
+        if from_version > RESULT_SCHEMA_VERSION:
+            logger.warning(
+                "CalculationResult dump was created with schema version %d, "
+                "but this code only understands version %d. "
+                "Some fields may be missing or misinterpreted.",
+                from_version,
+                RESULT_SCHEMA_VERSION,
+            )
+        elif from_version < RESULT_SCHEMA_VERSION:
             logger.warning(
                 "Migrating CalculationResult from schema version %d to %d.",
                 from_version,

--- a/tests/common/test_input_serialization.py
+++ b/tests/common/test_input_serialization.py
@@ -396,6 +396,24 @@ class TestCalculationInputSerialization:
 
         assert "Migrating CalculationInput" in caplog.text
 
+    def test_from_dict_logs_warning_on_future_schema(self, caplog):
+        """loading a dump from a newer schema version emits a warning."""
+        import logging
+
+        data = {
+            "charge": 0,
+            "spin_multiplicity": 1,
+            "task": "energy",
+            "level_of_theory": "b3lyp",
+            "basis_set": "6-31g*",
+            "schema_version": INPUT_SCHEMA_VERSION + 1,
+        }
+
+        with caplog.at_level(logging.WARNING, logger="calcflow.common.input"):
+            CalculationInput.from_dict(data)
+
+        assert "only understands version" in caplog.text
+
     def test_from_dict_raises_on_unknown_top_level_key(self):
         data = {
             "charge": 0,

--- a/tests/common/test_results_serialization.py
+++ b/tests/common/test_results_serialization.py
@@ -482,9 +482,6 @@ class TestCalculationResultSerialization:
 
     def test_from_dict_logs_warning_on_old_schema(self, caplog):
         """migration from an older schema version emits a warning."""
-        # This test is future-proof: once RESULT_SCHEMA_VERSION > 1,
-        # loading a v1 dump should warn.  For now with version 1, we
-        # simulate by passing from_version=0 indirectly.
         import logging
 
         data = {
@@ -498,6 +495,22 @@ class TestCalculationResultSerialization:
             CalculationResult.from_dict(data)
 
         assert "Migrating CalculationResult" in caplog.text
+
+    def test_from_dict_logs_warning_on_future_schema(self, caplog):
+        """loading a dump from a newer schema version emits a warning."""
+        import logging
+
+        data = {
+            "termination_status": "NORMAL",
+            "metadata": {"software_name": "ORCA"},
+            "final_energy": -75.0,
+            "schema_version": RESULT_SCHEMA_VERSION + 1,
+        }
+
+        with caplog.at_level(logging.WARNING, logger="calcflow.common.results"):
+            CalculationResult.from_dict(data)
+
+        assert "only understands version" in caplog.text
 
     def test_to_dict_excludes_raw_output(self):
         result = CalculationResult(


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `schema_version` integer field to the serialized dumps of both `CalculationInput` and `CalculationResult`, complementing the existing `calcflow_version` semver string. The change adds a skeletal `_migrate()` method to each class that is designed to apply sequential data-shape migrations as the schema evolves, and includes backward-compatible handling for old dumps that lack the field (defaulted to version 1).

Key changes:
- `INPUT_SCHEMA_VERSION = 1` and `RESULT_SCHEMA_VERSION = 1` module-level constants are introduced as the single source of truth for the current schema version.
- `to_dict()` on both classes now writes `schema_version` into the output dictionary.
- `from_dict()` on both classes pops `schema_version` (defaulting to 1 if absent), calls `_migrate()`, and proceeds with construction.
- `_migrate()` is a `@staticmethod` that logs a `WARNING` when migrating from an older version and contains placeholder comments for future migration blocks.
- New tests cover the four key scenarios: `to_dict` includes the field, `from_dict` strips it, missing field defaults to 1, and loading an older schema emits a warning.
- **One issue found**: Neither `_migrate()` implementation guards against `from_version > current_schema_version`. Loading a dump produced by a newer version of the code (e.g., `schema_version=3` loaded by code at `schema_version=1`) silently passes through without any warning or error, potentially producing an incomplete or corrupted object. A symmetric `elif from_version > CURRENT_VERSION` warning branch should be added.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the core schema versioning mechanism is correct and backward-compatible; the missing forward-version guard is a robustness gap that only matters when future schema versions exist.
- The change is purely additive and backward-compatible (old dumps without schema_version are handled gracefully). The migration scaffolding is well-designed and the tests cover the main happy paths. The only real issue is that loading a dump from a newer schema version passes silently with no diagnostic, but this will only become a live problem once the schema version is incremented beyond 1 in the future.
- src/calcflow/common/input.py and src/calcflow/common/results.py — both _migrate() implementations need a forward-version guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/calcflow/common/input.py | Adds INPUT_SCHEMA_VERSION constant, schema_version to to_dict(), and a _migrate() static method. The migration path for older versions is well-structured, but there is no guard for future schema versions (from_version > INPUT_SCHEMA_VERSION), which silently returns data as-is. |
| src/calcflow/common/results.py | Mirrors the input.py pattern with RESULT_SCHEMA_VERSION, schema_version in to_dict(), and _migrate(). Has the same missing guard for future schema versions as input.py. |
| tests/common/test_input_serialization.py | Adds four new tests covering schema_version in to_dict, stripping in from_dict, backward-compat default, and warning on old schema. All well-structured and cover the intended behaviors. |
| tests/common/test_results_serialization.py | Adds four corresponding tests for CalculationResult serialization. Uses schema_version=0 to trigger the migration warning since the current version is 1. No test for from_version > current_schema_version. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["from_dict(data)"] --> B["pop calcflow_version"]
    B --> C["incoming_version = pop schema_version\n(default: 1)"]
    C --> D["_migrate(data, incoming_version)"]
    D --> E{from_version < SCHEMA_VERSION?}
    E -- Yes --> F["logger.warning(Migrating v{N} → v{M})"]
    F --> G["apply migration steps (future)"]
    E -- No --> H["return data unchanged"]
    G --> H
    H --> I["construct dataclass"]

    D2{from_version > SCHEMA_VERSION?}
    E -- "⚠️ Not checked" --> D2
    D2 -- "Silent pass-through\n(no warning)" --> H

    style D2 fill:#ffcccc,stroke:#cc0000
```

<sub>Last reviewed commit: 60f7045</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->