### PR TITLE
perf: fast-path substring guards + short-circuit ordering fixes in parser matches()

### DIFF
--- a/src/calcflow/io/orca/blocks/charges.py
+++ b/src/calcflow/io/orca/blocks/charges.py
@@ -46,7 +46,9 @@ class ChargesParser:
             return False
         if "MULLIKEN" not in line and "LOEWDIN" not in line:
             return False
-        return bool(MULLIKEN_START_PAT.search(line)) or bool(LOEWDIN_START_PAT.search(line))
+        if not state.parsed_mulliken and MULLIKEN_START_PAT.search(line):
+            return True
+        return not state.parsed_loewdin and bool(LOEWDIN_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """

--- a/src/calcflow/io/orca/blocks/charges.py
+++ b/src/calcflow/io/orca/blocks/charges.py
@@ -40,8 +40,12 @@ class ChargesParser:
         Check if this line marks the beginning of an atomic charges block.
 
         Returns True for either MULLIKEN or LOEWDIN atomic charges headers.
-        Note: No state flag check - allows parser to run multiple times (once per method).
+        Allows the parser to run twice (once per method); stops after both are parsed.
         """
+        if state.parsed_mulliken and state.parsed_loewdin:
+            return False
+        if "MULLIKEN" not in line and "LOEWDIN" not in line:
+            return False
         return bool(MULLIKEN_START_PAT.search(line)) or bool(LOEWDIN_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:

--- a/src/calcflow/io/orca/blocks/dispersion.py
+++ b/src/calcflow/io/orca/blocks/dispersion.py
@@ -51,6 +51,8 @@ class DispersionParser:
         """
         Check if this line marks the start of a dispersion block.
         """
+        if "DISPERSION CORRECTION" not in line:
+            return False
         if state.parsed_dispersion:
             return False
         return bool(START_PAT.search(line))

--- a/src/calcflow/io/orca/blocks/finalization.py
+++ b/src/calcflow/io/orca/blocks/finalization.py
@@ -9,6 +9,8 @@ NORMAL_TERM_PAT = re.compile(r"\*\*\*\*ORCA TERMINATED NORMALLY\*\*\*\*")
 
 class FinalEnergyParser:
     def matches(self, line: str, state: ParseState) -> bool:
+        if "FINAL SINGLE POINT ENERGY" not in line:
+            return False
         return state.final_energy is None and bool(FINAL_ENERGY_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
@@ -19,6 +21,8 @@ class FinalEnergyParser:
 
 class TerminationParser:
     def matches(self, line: str, state: ParseState) -> bool:
+        if "ORCA TERMINATED" not in line:
+            return False
         return state.termination_status == "UNKNOWN" and bool(NORMAL_TERM_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:

--- a/src/calcflow/io/orca/blocks/geometry.py
+++ b/src/calcflow/io/orca/blocks/geometry.py
@@ -13,6 +13,8 @@ GEOMETRY_LINE_PAT = re.compile(r"^\s*([A-Za-z]{1,3})\s+(-?\d+\.\d+)\s+(-?\d+\.\d
 
 class GeometryParser:
     def matches(self, line: str, state: ParseState) -> bool:
+        if "CARTESIAN COORDINATES" not in line:
+            return False
         return not state.parsed_geometry and bool(GEOMETRY_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:

--- a/src/calcflow/io/orca/blocks/orbitals.py
+++ b/src/calcflow/io/orca/blocks/orbitals.py
@@ -50,6 +50,8 @@ class OrbitalsParser:
         Returns:
             True if this is the start of an orbital block and hasn't been parsed yet.
         """
+        if "ORBITAL ENERGIES" not in line:
+            return False
         if state.parsed_orbitals:
             return False
         return bool(ORBITAL_ENERGIES_START_PAT.search(line))

--- a/src/calcflow/io/orca/blocks/timing.py
+++ b/src/calcflow/io/orca/blocks/timing.py
@@ -35,6 +35,8 @@ class TimingParser:
 
     def matches(self, line: str, state: ParseState) -> bool:
         """Matches on total wall time line or module timing lines."""
+        if "..." not in line and "TOTAL RUN TIME" not in line:
+            return False
         if state.parsed_timing:
             return False
         return bool(TOTAL_TIME_PAT.search(line)) or bool(MODULE_TIME_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/adc/excited_states.py
+++ b/src/calcflow/io/qchem/blocks/adc/excited_states.py
@@ -56,6 +56,8 @@ class AdcExcitedStatesParser(BlockParser):
     START_PAT: ClassVar[re.Pattern] = re.compile(r"Excited State Summary")
 
     def matches(self, line: str, state: ParseState) -> bool:
+        if "Excited State Summary" not in line:
+            return False
         if state.parsed_adc_excited:
             return False
         return bool(self.START_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/adc/ground_state.py
+++ b/src/calcflow/io/qchem/blocks/adc/ground_state.py
@@ -41,6 +41,8 @@ class AdcGroundStateParser(BlockParser):
     DAVIDSON_PAT: ClassVar[re.Pattern] = re.compile(r"Starting Davidson for excited states")
 
     def matches(self, line: str, state: ParseState) -> bool:
+        if "A D C" not in line:
+            return False
         if state.parsed_adc_gs:
             return False
         return bool(self.BANNER_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/charges.py
+++ b/src/calcflow/io/qchem/blocks/charges.py
@@ -40,7 +40,9 @@ class MullikenParser:
         Returns True only if we haven't already parsed Mulliken charges and the line
         contains the Mulliken charges header.
         """
-        return bool(MULLIKEN_START_PAT.search(line)) and not state.parsed_mulliken
+        if "Mulliken" not in line:
+            return False
+        return not state.parsed_mulliken and bool(MULLIKEN_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """

--- a/src/calcflow/io/qchem/blocks/cm5.py
+++ b/src/calcflow/io/qchem/blocks/cm5.py
@@ -32,7 +32,9 @@ class Cm5Parser:
     """
 
     def matches(self, line: str, state: ParseState) -> bool:
-        return bool(CM5_START_PAT.search(line)) and not state.parsed_cm5
+        if "Charge Model 5" not in line:
+            return False
+        return not state.parsed_cm5 and bool(CM5_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Parsing QChem CM5 charges block.")

--- a/src/calcflow/io/qchem/blocks/geometry.py
+++ b/src/calcflow/io/qchem/blocks/geometry.py
@@ -41,7 +41,7 @@ class GeometryParser:
             return True
         # The final geometry is part of the main calculation, not a separate block to be parsed once
         # For now, let's assume we only parse the final geometry once.
-        return state.final_geometry is None and STANDARD_GEOM_START_PAT.search(line) is not None
+        return state.final_geometry is None and bool(STANDARD_GEOM_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """Delegates to the appropriate parsing method based on the start line."""

--- a/src/calcflow/io/qchem/blocks/geometry.py
+++ b/src/calcflow/io/qchem/blocks/geometry.py
@@ -34,12 +34,14 @@ class GeometryParser:
 
     def matches(self, line: str, state: ParseState) -> bool:
         """Checks if the line starts either the input or standard geometry block."""
-        if INPUT_GEOM_START_PAT.search(line) and not state.parsed_geometry:
+        if "$molecule" not in line.lower() and "Standard Nuclear Orientation" not in line:
+            return False
+        if not state.parsed_geometry and INPUT_GEOM_START_PAT.search(line):
             # We use a single 'parsed_geometry' flag for the input geometry
             return True
         # The final geometry is part of the main calculation, not a separate block to be parsed once
         # For now, let's assume we only parse the final geometry once.
-        return (STANDARD_GEOM_START_PAT.search(line) is not None) and state.final_geometry is None
+        return state.final_geometry is None and STANDARD_GEOM_START_PAT.search(line) is not None
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """Delegates to the appropriate parsing method based on the start line."""

--- a/src/calcflow/io/qchem/blocks/hirshfeld.py
+++ b/src/calcflow/io/qchem/blocks/hirshfeld.py
@@ -34,7 +34,9 @@ class HirshfeldParser:
     """
 
     def matches(self, line: str, state: ParseState) -> bool:
-        return bool(HIRSHFELD_START_PAT.search(line)) and not state.parsed_hirshfeld
+        if "Hirshfeld" not in line:
+            return False
+        return not state.parsed_hirshfeld and bool(HIRSHFELD_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Parsing QChem Hirshfeld charges block.")

--- a/src/calcflow/io/qchem/blocks/metadata.py
+++ b/src/calcflow/io/qchem/blocks/metadata.py
@@ -23,6 +23,8 @@ class MetadataParser:
         """
         if state.metadata.software_version is not None:
             return False
+        if "Q-Chem" not in line:
+            return False
         return QCHEM_VERSION_PAT.search(line) is not None
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:

--- a/src/calcflow/io/qchem/blocks/metadata.py
+++ b/src/calcflow/io/qchem/blocks/metadata.py
@@ -25,7 +25,7 @@ class MetadataParser:
             return False
         if "Q-Chem" not in line:
             return False
-        return QCHEM_VERSION_PAT.search(line) is not None
+        return bool(QCHEM_VERSION_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """

--- a/src/calcflow/io/qchem/blocks/multipole.py
+++ b/src/calcflow/io/qchem/blocks/multipole.py
@@ -60,7 +60,9 @@ class MultipoleParser:
 
     def matches(self, line: str, state: ParseState) -> bool:
         """Check if this line marks the beginning of the multipole moments block."""
-        return bool(MULTIPOLE_START_PAT.search(line)) and not state.parsed_multipole
+        if "Multipole Moments" not in line:
+            return False
+        return not state.parsed_multipole and bool(MULTIPOLE_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """

--- a/src/calcflow/io/qchem/blocks/orbitals.py
+++ b/src/calcflow/io/qchem/blocks/orbitals.py
@@ -39,6 +39,8 @@ class OrbitalsParser:
 
     def matches(self, line: str, state: ParseState) -> bool:
         """Check if this line marks the start of the orbital energies block."""
+        if "Orbital Energies" not in line:
+            return False
         if state.parsed_orbitals:
             return False
         return bool(ORBITAL_BLOCK_START_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/scf.py
+++ b/src/calcflow/io/qchem/blocks/scf.py
@@ -33,6 +33,8 @@ class ScfParser:
     """Parses the main SCF block, including iterations, final energies, and SMD summaries."""
 
     def matches(self, line: str, state: ParseState) -> bool:
+        if "General SCF" not in line:
+            return False
         return not state.parsed_scf and bool(SCF_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:

--- a/src/calcflow/io/qchem/blocks/tddft/excitations.py
+++ b/src/calcflow/io/qchem/blocks/tddft/excitations.py
@@ -56,6 +56,8 @@ class ExcitationsParser:
 
         Matches either TDA or full TDDFT block start, and only if not already parsed.
         """
+        if "Excitation" not in line:
+            return False
         if state.parsed_tddft_tda and state.parsed_tddft_full:
             return False
 

--- a/src/calcflow/io/qchem/blocks/tddft/gs_ref.py
+++ b/src/calcflow/io/qchem/blocks/tddft/gs_ref.py
@@ -65,6 +65,8 @@ class GroundStateRefParser:
 
         Matches "Ground State (Reference) :" and only if not already parsed.
         """
+        if "Ground State" not in line:
+            return False
         if state.parsed_tddft_gs_ref:
             return False
 

--- a/src/calcflow/io/qchem/blocks/tddft/nto.py
+++ b/src/calcflow/io/qchem/blocks/tddft/nto.py
@@ -54,6 +54,8 @@ class NTOParser:
 
         Returns False if already parsed.
         """
+        if "NTO" not in line:
+            return False
         if state.parsed_nto:
             return False
 

--- a/src/calcflow/io/qchem/blocks/tddft/trans_dm.py
+++ b/src/calcflow/io/qchem/blocks/tddft/trans_dm.py
@@ -46,6 +46,8 @@ class TransitionDensityMatrixParser(BlockParser):
     END_PAT: ClassVar[re.Pattern] = re.compile(r"^\s*-{5,}\s*$")
 
     def matches(self, line: str, state: ParseState) -> bool:
+        if "Transition Density" not in line:
+            return False
         if state.parsed_tddft_trans_dm:
             return False
         return bool(self.START_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/tddft/unrel_dm.py
+++ b/src/calcflow/io/qchem/blocks/tddft/unrel_dm.py
@@ -46,6 +46,8 @@ class UnrelaxedDensityMatrixParser(BlockParser):
     END_PAT: ClassVar[re.Pattern] = re.compile(r"^\s*-{5,}\s*$")
 
     def matches(self, line: str, state: ParseState) -> bool:
+        if "Unrelaxed" not in line:
+            return False
         if state.parsed_tddft_unrelaxed_dm:
             return False
         return bool(self.START_PAT.search(line))

--- a/src/calcflow/io/qchem/blocks/timing.py
+++ b/src/calcflow/io/qchem/blocks/timing.py
@@ -23,6 +23,8 @@ class TimingParser:
 
     def matches(self, line: str, state: ParseState) -> bool:
         """Matches on the total job time line."""
+        if "Total job time" not in line:
+            return False
         if state.parsed_timing:
             return False
         return bool(TOTAL_TIME_PAT.search(line))


### PR DESCRIPTION
## Summary

- **Fast-path `in` guards** added to 22 `matches()` methods (15 Q-Chem + 7 ORCA parsers): each now begins with a cheap `if "KEYWORD" not in line: return False` before invoking the regex engine. On non-matching lines (the common case), this reduces `matches()` cost from O(regex) to O(substring).

- **Short-circuit ordering fixed** in 5 parsers where regex ran before the boolean state flag: `GeometryParser` (Q-Chem), `MullikenParser`, `HirshfeldParser`, `Cm5Parser`, `MultipoleParser`. The O(1) state flag check now always precedes the O(n) regex.

- **ORCA `ChargesParser`** had no state guard at all — it ran two regex searches on every line for the entire file even after both Mulliken and Loewdin were parsed. Added a combined completion guard (`if state.parsed_mulliken and state.parsed_loewdin: return False`) plus a keyword fast-path (`"MULLIKEN"` / `"LOEWDIN"`).

- **Q-Chem `TerminationParser`** intentionally left without a fast-path guard: its `ERROR_TERM_PAT` is a broad 4-keyword `IGNORECASE` catch-all; the existing `termination_status != "UNKNOWN"` guard already short-circuits once the status is decided.

## Files changed (22)

**Q-Chem:** `metadata.py`, `geometry.py`, `scf.py`, `charges.py`, `hirshfeld.py`, `cm5.py`, `orbitals.py`, `multipole.py`, `timing.py`, `tddft/excitations.py`, `tddft/nto.py`, `tddft/gs_ref.py`, `tddft/unrel_dm.py`, `tddft/trans_dm.py`, `adc/ground_state.py`, `adc/excited_states.py`

**ORCA:** `charges.py`, `geometry.py`, `orbitals.py`, `dispersion.py`, `finalization.py` (both parsers), `timing.py`

## Verification

All 1924 tests pass (`uv run pytest --tb=short -q`). `uvx ruff check` clean on all changed files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds O(substring) fast-path keyword guards to 22 `matches()` methods across Q-Chem and ORCA parsers, and fixes short-circuit evaluation ordering in 5 parsers so that cheap O(1) state-flag checks always precede O(n) regex searches. The net effect is that the hot path — the overwhelming majority of lines in an output file that don't begin any block — now returns `False` after a single `in` membership test rather than invoking the regex engine.

Key changes:
- **22 keyword guards added**: each `matches()` now opens with `if "LITERAL" not in line: return False`, where `"LITERAL"` is always a substring of the corresponding compiled regex pattern, guaranteeing no false negatives.
- **5 short-circuit ordering fixes** (`GeometryParser`, `MullikenParser`, `HirshfeldParser`, `Cm5Parser`, `MultipoleParser`): expressions like `bool(PAT.search(line)) and not state.parsed_X` were reversed to `not state.parsed_X and bool(PAT.search(line))` so the O(1) flag is evaluated first under Python's short-circuit `and`.
- **ORCA `ChargesParser`** received a combined completion guard (`if state.parsed_mulliken and state.parsed_loewdin: return False`) plus keyword guards, eliminating two unbounded regex searches per line for the entire file length once both charge types are captured.
- All 1924 existing tests pass with no behaviour changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure performance optimisation with no semantic behaviour changes.
- Every keyword guard string is a literal substring of its corresponding compiled regex, so no guard can produce a false negative. The five short-circuit reorderings are straightforward Python and-expression swaps. The ORCA ChargesParser combined guard is logically correct for both Mulliken-only and Loewdin-only files (the guard only exits early when both flags are true, so a single-type file continues matching as before). All 1924 tests pass.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/calcflow/io/orca/blocks/charges.py | Added combined completion guard (parsed_mulliken AND parsed_loewdin) and keyword fast-path for "MULLIKEN"/"LOEWDIN". Logic is correct; combined guard correctly defers exit until both charge types are parsed regardless of order. |
| src/calcflow/io/orca/blocks/finalization.py | Added keyword guards for both FinalEnergyParser ("FINAL SINGLE POINT ENERGY") and TerminationParser ("ORCA TERMINATED"). Both guards are exact substrings of their corresponding regex patterns. |
| src/calcflow/io/orca/blocks/timing.py | Added dual keyword guard: "..." for module timing lines and "TOTAL RUN TIME" for the total time line. The "..." guard is broad (passes any line with three consecutive dots) but correctly covers all MODULE_TIME_PAT matches. |
| src/calcflow/io/qchem/blocks/geometry.py | Added keyword guard using line.lower() for "$molecule" (handling IGNORECASE flag) and direct "Standard Nuclear Orientation" check. Short-circuit ordering also fixed: state flag now precedes regex in both branches. |
| src/calcflow/io/qchem/blocks/charges.py | Fixed short-circuit order (state flag now before regex) and added "Mulliken" keyword guard. Pattern MULLIKEN_START_PAT contains "Mulliken" so the guard is a correct pre-filter. |
| src/calcflow/io/qchem/blocks/scf.py | Added "General SCF" keyword guard; matches prefix of SCF_START_PAT ("General SCF calculation program by"). Clean and correct. |
| src/calcflow/io/qchem/blocks/multipole.py | Fixed short-circuit order and added "Multipole Moments" keyword guard. MULTIPOLE_START_PAT ("Cartesian Multipole Moments") contains the guard substring. |
| src/calcflow/io/qchem/blocks/tddft/excitations.py | Added "Excitation" keyword guard before the combined TDA/TDDFT state check. Both TDA_START_PAT and TDDFT_START_PAT contain "Excitation", making this guard correct. |
| src/calcflow/io/qchem/blocks/adc/ground_state.py | Added "A D C" keyword guard for BANNER_PAT ("A D C\s+M A N"). The guard is a substring of the pattern. Correctly placed before state flag. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CoreParser: next line] --> B{Keyword guard}
    B -->|KEYWORD not in line - skip| A
    B -->|KEYWORD in line - proceed| C{State flag check}
    C -->|already parsed - skip| A
    C -->|not yet parsed - proceed| D[Regex search]
    D -->|no match| A
    D -->|match| E[parse called - state updated]
    E --> A
```

<sub>Last reviewed commit: 77044d1</sub>

<!-- /greptile_comment -->