### PR TITLE
ref: replace ParseState boolean flags with parsed_blocks set

### DIFF
--- a/src/calcflow/io/orca/blocks/charges.py
+++ b/src/calcflow/io/orca/blocks/charges.py
@@ -10,7 +10,7 @@ import re
 
 from calcflow.common.results import AtomicCharges
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_LOEWDIN, BLOCK_MULLIKEN, ParseState
 from calcflow.utils import logger
 
 # Regex patterns for identifying charge blocks
@@ -42,13 +42,13 @@ class ChargesParser:
         Returns True for either MULLIKEN or LOEWDIN atomic charges headers.
         Allows the parser to run twice (once per method); stops after both are parsed.
         """
-        if state.parsed_mulliken and state.parsed_loewdin:
+        if BLOCK_MULLIKEN in state.parsed_blocks and BLOCK_LOEWDIN in state.parsed_blocks:
             return False
         if "MULLIKEN" not in line and "LOEWDIN" not in line:
             return False
-        if not state.parsed_mulliken and MULLIKEN_START_PAT.search(line):
+        if BLOCK_MULLIKEN not in state.parsed_blocks and MULLIKEN_START_PAT.search(line):
             return True
-        return not state.parsed_loewdin and bool(LOEWDIN_START_PAT.search(line))
+        return BLOCK_LOEWDIN not in state.parsed_blocks and bool(LOEWDIN_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """
@@ -102,6 +102,6 @@ class ChargesParser:
         logger.debug(f"Parsed {method} charges for {len(charges)} atoms")
 
         if method == "Mulliken":
-            state.parsed_mulliken = True
+            state.parsed_blocks.add(BLOCK_MULLIKEN)
         elif method == "Loewdin":
-            state.parsed_loewdin = True
+            state.parsed_blocks.add(BLOCK_LOEWDIN)

--- a/src/calcflow/io/orca/blocks/dipole.py
+++ b/src/calcflow/io/orca/blocks/dipole.py
@@ -4,7 +4,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import FLOAT_PAT
 from calcflow.common.results import DipoleMoment, MultipoleResults
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_DIPOLE, ParseState
 from calcflow.utils import logger
 
 # Pattern to match the start of the dipole block (e.g., "DIPOLE MOMENT")
@@ -26,7 +26,7 @@ class DipoleParser:
 
         The dipole block in ORCA output is identified by a line containing "DIPOLE MOMENT".
         """
-        if state.parsed_dipole:
+        if BLOCK_DIPOLE in state.parsed_blocks:
             return False
         return "DIPOLE MOMENT" in line
 
@@ -104,5 +104,5 @@ class DipoleParser:
                 quadrupole=state.multipole.quadrupole,
             )
 
-        state.parsed_dipole = True
+        state.parsed_blocks.add(BLOCK_DIPOLE)
         logger.debug("Finished parsing dipole moment block.")

--- a/src/calcflow/io/orca/blocks/dispersion.py
+++ b/src/calcflow/io/orca/blocks/dispersion.py
@@ -4,7 +4,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import FLOAT_PAT
 from calcflow.common.results import DispersionCorrection
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_DISPERSION, ParseState
 from calcflow.utils import logger
 
 # Block markers
@@ -53,7 +53,7 @@ class DispersionParser:
         """
         if "DISPERSION CORRECTION" not in line:
             return False
-        if state.parsed_dispersion:
+        if BLOCK_DISPERSION in state.parsed_blocks:
             return False
         return bool(START_PAT.search(line))
 
@@ -198,5 +198,5 @@ class DispersionParser:
             e8_percentage=self.e8_percentage,
         )
 
-        state.parsed_dispersion = True
+        state.parsed_blocks.add(BLOCK_DISPERSION)
         logger.debug("Finished parsing dispersion block.")

--- a/src/calcflow/io/orca/blocks/geometry.py
+++ b/src/calcflow/io/orca/blocks/geometry.py
@@ -4,7 +4,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.models import Atom
 from calcflow.geometry.static import Geometry
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_GEOMETRY, ParseState
 from calcflow.utils import logger
 
 GEOMETRY_START_PAT = re.compile(r"CARTESIAN COORDINATES \(ANGSTROEM\)")
@@ -15,7 +15,7 @@ class GeometryParser:
     def matches(self, line: str, state: ParseState) -> bool:
         if "CARTESIAN COORDINATES" not in line:
             return False
-        return not state.parsed_geometry and bool(GEOMETRY_START_PAT.search(line))
+        return BLOCK_GEOMETRY not in state.parsed_blocks and bool(GEOMETRY_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Parsing geometry block.")
@@ -31,5 +31,5 @@ class GeometryParser:
             raise ParsingError("Geometry block found but no atoms parsed.")
 
         state.input_geometry = Geometry(comment="", atoms=tuple(geometry))
-        state.parsed_geometry = True
+        state.parsed_blocks.add(BLOCK_GEOMETRY)
         logger.debug(f"Parsed {len(geometry)} atoms.")

--- a/src/calcflow/io/orca/blocks/orbitals.py
+++ b/src/calcflow/io/orca/blocks/orbitals.py
@@ -11,7 +11,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import SIGNED_FIXED_FLOAT_PAT
 from calcflow.common.results import Orbital, OrbitalsSet
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_ORBITALS, ParseState
 from calcflow.utils import logger
 
 # Regex pattern for the start of the orbital energies block
@@ -52,7 +52,7 @@ class OrbitalsParser:
         """
         if "ORBITAL ENERGIES" not in line:
             return False
-        if state.parsed_orbitals:
+        if BLOCK_ORBITALS in state.parsed_blocks:
             return False
         return bool(ORBITAL_ENERGIES_START_PAT.search(line))
 
@@ -121,5 +121,5 @@ class OrbitalsParser:
         )
 
         state.orbitals = orbitals_set
-        state.parsed_orbitals = True
+        state.parsed_blocks.add(BLOCK_ORBITALS)
         logger.debug(f"Successfully parsed {len(orbitals)} orbitals. HOMO index: {homo_idx}, LUMO index: {lumo_idx}")

--- a/src/calcflow/io/orca/blocks/scf.py
+++ b/src/calcflow/io/orca/blocks/scf.py
@@ -4,7 +4,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import FLOAT_PAT
 from calcflow.common.results import ScfEnergyComponents, ScfIteration, ScfResults
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_SCF, ParseState
 from calcflow.utils import logger
 
 SCF_CONVERGED_LINE_PAT = re.compile(r"SCF CONVERGED AFTER\s+(\d+)\s+CYCLES")
@@ -46,7 +46,7 @@ class ScfParser:
         self.iterations: list[ScfIteration] = []
 
     def matches(self, line: str, state: ParseState) -> bool:
-        return not state.parsed_scf and "D-I-I-S" in line
+        return BLOCK_SCF not in state.parsed_blocks and "D-I-I-S" in line
 
     def _is_iteration_line(self, line: str) -> bool:
         """Check if line is a numeric iteration line (starts with whitespace + number)."""
@@ -180,4 +180,4 @@ class ScfParser:
             iterations=self.iterations,
             components=components,
         )
-        state.parsed_scf = True
+        state.parsed_blocks.add(BLOCK_SCF)

--- a/src/calcflow/io/orca/blocks/timing.py
+++ b/src/calcflow/io/orca/blocks/timing.py
@@ -10,7 +10,7 @@ import re
 
 from calcflow.common.results import TimingResults
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_TIMING, ParseState
 
 # Pattern for total wall time: "TOTAL RUN TIME: 0 days 0 hours 1 minutes 31 seconds 640 msec"
 TOTAL_TIME_PAT = re.compile(
@@ -37,7 +37,7 @@ class TimingParser:
         """Matches on total wall time line or module timing lines."""
         if "..." not in line and "TOTAL RUN TIME" not in line:
             return False
-        if state.parsed_timing:
+        if BLOCK_TIMING in state.parsed_blocks:
             return False
         return bool(TOTAL_TIME_PAT.search(line)) or bool(MODULE_TIME_PAT.search(line))
 
@@ -63,7 +63,7 @@ class TimingParser:
                 total_wall_time_seconds=total_wall_seconds,
                 module_times=module_times,
             )
-            state.parsed_timing = True
+            state.parsed_blocks.add(BLOCK_TIMING)
             # Reset buffer for potential future use
             self.module_times_buffer = {}
         else:

--- a/src/calcflow/io/qchem/blocks/adc/excited_states.py
+++ b/src/calcflow/io/qchem/blocks/adc/excited_states.py
@@ -40,6 +40,7 @@ from calcflow.io.core import BlockParser, ParseState
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.parse_helpers import parse_key_value as _parse_kv
 from calcflow.io.qchem.blocks.parse_helpers import parse_vector as _parse_vec
+from calcflow.io.state import BLOCK_ADC_EXCITED
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class AdcExcitedStatesParser(BlockParser):
     def matches(self, line: str, state: ParseState) -> bool:
         if "Excited State Summary" not in line:
             return False
-        if state.parsed_adc_excited:
+        if BLOCK_ADC_EXCITED in state.parsed_blocks:
             return False
         return bool(self.START_PAT.search(line))
 
@@ -98,7 +99,7 @@ class AdcExcitedStatesParser(BlockParser):
             logger.warning("AdcExcitedStatesParser: no states parsed.")
 
         state.adc_excited_states = excited_states
-        state.parsed_adc_excited = True
+        state.parsed_blocks.add(BLOCK_ADC_EXCITED)
         logger.debug(f"Finished parsing {len(excited_states)} ADC excited states.")
 
     # ------------------------------------------------------------------

--- a/src/calcflow/io/qchem/blocks/adc/ground_state.py
+++ b/src/calcflow/io/qchem/blocks/adc/ground_state.py
@@ -29,6 +29,7 @@ from calcflow.io.core import BlockParser, ParseState
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.parse_helpers import parse_key_value as _parse_kv
 from calcflow.io.qchem.blocks.parse_helpers import parse_vector as _parse_vec
+from calcflow.io.state import BLOCK_ADC_GS
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class AdcGroundStateParser(BlockParser):
     def matches(self, line: str, state: ParseState) -> bool:
         if "A D C" not in line:
             return False
-        if state.parsed_adc_gs:
+        if BLOCK_ADC_GS in state.parsed_blocks:
             return False
         return bool(self.BANNER_PAT.search(line))
 
@@ -114,7 +115,7 @@ class AdcGroundStateParser(BlockParser):
             return
 
         state.adc_ground_state = gs
-        state.parsed_adc_gs = True
+        state.parsed_blocks.add(BLOCK_ADC_GS)
         logger.debug("Finished parsing ADC ground state block.")
 
     # ------------------------------------------------------------------

--- a/src/calcflow/io/qchem/blocks/charges.py
+++ b/src/calcflow/io/qchem/blocks/charges.py
@@ -10,7 +10,7 @@ import re
 from calcflow.common.patterns import extract_index
 from calcflow.common.results import AtomicCharges
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_MULLIKEN, ParseState
 from calcflow.utils import logger
 
 # Regex pattern for identifying the Mulliken charges block header
@@ -42,7 +42,7 @@ class MullikenParser:
         """
         if "Mulliken" not in line:
             return False
-        return not state.parsed_mulliken and bool(MULLIKEN_START_PAT.search(line))
+        return BLOCK_MULLIKEN not in state.parsed_blocks and bool(MULLIKEN_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """
@@ -87,4 +87,4 @@ class MullikenParser:
         logger.debug(f"Parsed Mulliken charges for {len(charges)} atoms")
 
         # Set flag to prevent duplicate parsing
-        state.parsed_mulliken = True
+        state.parsed_blocks.add(BLOCK_MULLIKEN)

--- a/src/calcflow/io/qchem/blocks/cm5.py
+++ b/src/calcflow/io/qchem/blocks/cm5.py
@@ -12,7 +12,7 @@ import re
 from calcflow.common.patterns import extract_index
 from calcflow.common.results import AtomicCharges
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_CM5, ParseState
 from calcflow.utils import logger
 
 CM5_START_PAT = re.compile(r"Charge Model 5")
@@ -34,7 +34,7 @@ class Cm5Parser:
     def matches(self, line: str, state: ParseState) -> bool:
         if "Charge Model 5" not in line:
             return False
-        return not state.parsed_cm5 and bool(CM5_START_PAT.search(line))
+        return BLOCK_CM5 not in state.parsed_blocks and bool(CM5_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Parsing QChem CM5 charges block.")
@@ -57,5 +57,5 @@ class Cm5Parser:
             return
 
         state.atomic_charges.append(AtomicCharges(method="CM5", charges=charges))
-        state.parsed_cm5 = True
+        state.parsed_blocks.add(BLOCK_CM5)
         logger.debug(f"Parsed CM5 charges for {len(charges)} atoms")

--- a/src/calcflow/io/qchem/blocks/geometry.py
+++ b/src/calcflow/io/qchem/blocks/geometry.py
@@ -9,7 +9,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.models import Atom
 from calcflow.geometry.static import Geometry
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_GEOMETRY, ParseState
 from calcflow.utils import logger
 
 # --- Regex Patterns ---
@@ -36,7 +36,7 @@ class GeometryParser:
         """Checks if the line starts either the input or standard geometry block."""
         if "$molecule" not in line.lower() and "Standard Nuclear Orientation" not in line:
             return False
-        if not state.parsed_geometry and INPUT_GEOM_START_PAT.search(line):
+        if BLOCK_GEOMETRY not in state.parsed_blocks and INPUT_GEOM_START_PAT.search(line):
             # We use a single 'parsed_geometry' flag for the input geometry
             return True
         # The final geometry is part of the main calculation, not a separate block to be parsed once
@@ -60,7 +60,7 @@ class GeometryParser:
         first_line = next(iterator, None)
         if first_line and first_line.strip().lower() == "read":
             logger.debug("Found '$molecule read' directive - skipping geometry parsing (inherited from previous job).")
-            state.parsed_geometry = True
+            state.parsed_blocks.add(BLOCK_GEOMETRY)
             return
 
         for line in iterator:
@@ -78,7 +78,7 @@ class GeometryParser:
             raise ParsingError("$molecule block found but no atoms could be parsed.")
 
         state.input_geometry = Geometry(comment="", atoms=tuple(atoms))
-        state.parsed_geometry = True  # Use the generic flag for the primary input geometry
+        state.parsed_blocks.add(BLOCK_GEOMETRY)  # Use the generic flag for the primary input geometry
         logger.debug(f"Parsed {len(atoms)} atoms from $molecule block.")
 
     def _parse_standard_orientation(self, iterator: PeekableIterator, state: ParseState) -> None:

--- a/src/calcflow/io/qchem/blocks/geometry.py
+++ b/src/calcflow/io/qchem/blocks/geometry.py
@@ -37,7 +37,7 @@ class GeometryParser:
         if "$molecule" not in line.lower() and "Standard Nuclear Orientation" not in line:
             return False
         if BLOCK_GEOMETRY not in state.parsed_blocks and INPUT_GEOM_START_PAT.search(line):
-            # We use a single 'parsed_geometry' flag for the input geometry
+            # We use BLOCK_GEOMETRY in parsed_blocks to track the input geometry
             return True
         # The final geometry is part of the main calculation, not a separate block to be parsed once
         # For now, let's assume we only parse the final geometry once.

--- a/src/calcflow/io/qchem/blocks/hirshfeld.py
+++ b/src/calcflow/io/qchem/blocks/hirshfeld.py
@@ -11,7 +11,7 @@ import re
 from calcflow.common.patterns import extract_index
 from calcflow.common.results import AtomicCharges
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_HIRSHFELD, ParseState
 from calcflow.utils import logger
 
 # Header pattern — note the trailing spaces in Q-Chem output are trimmed by search
@@ -36,7 +36,7 @@ class HirshfeldParser:
     def matches(self, line: str, state: ParseState) -> bool:
         if "Hirshfeld" not in line:
             return False
-        return not state.parsed_hirshfeld and bool(HIRSHFELD_START_PAT.search(line))
+        return BLOCK_HIRSHFELD not in state.parsed_blocks and bool(HIRSHFELD_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Parsing QChem Hirshfeld charges block.")
@@ -59,5 +59,5 @@ class HirshfeldParser:
             return
 
         state.atomic_charges.append(AtomicCharges(method="Hirshfeld", charges=charges))
-        state.parsed_hirshfeld = True
+        state.parsed_blocks.add(BLOCK_HIRSHFELD)
         logger.debug(f"Parsed Hirshfeld charges for {len(charges)} atoms")

--- a/src/calcflow/io/qchem/blocks/metadata.py
+++ b/src/calcflow/io/qchem/blocks/metadata.py
@@ -3,7 +3,7 @@ import re
 
 from calcflow.common.patterns import VersionSpec
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_METADATA, ParseState
 from calcflow.utils import logger
 
 # --- Regex Pattern ---
@@ -41,5 +41,5 @@ class MetadataParser:
                 software_version=normalized_version,
             )
             state.metadata = new_metadata
-            state.parsed_metadata = True
+            state.parsed_blocks.add(BLOCK_METADATA)
             logger.debug(f"Parsed Q-Chem version: {normalized_version}")

--- a/src/calcflow/io/qchem/blocks/multipole.py
+++ b/src/calcflow/io/qchem/blocks/multipole.py
@@ -16,7 +16,7 @@ from calcflow.common.results import (
     QuadrupoleMoment,
 )
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_MULTIPOLE, ParseState
 from calcflow.utils import logger
 
 # Regex patterns
@@ -62,7 +62,7 @@ class MultipoleParser:
         """Check if this line marks the beginning of the multipole moments block."""
         if "Multipole Moments" not in line:
             return False
-        return not state.parsed_multipole and bool(MULTIPOLE_START_PAT.search(line))
+        return BLOCK_MULTIPOLE not in state.parsed_blocks and bool(MULTIPOLE_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         """
@@ -181,7 +181,7 @@ class MultipoleParser:
         else:
             state.parsing_warnings.append("Multipole moments block found but no moments were parsed.")
 
-        state.parsed_multipole = True
+        state.parsed_blocks.add(BLOCK_MULTIPOLE)
 
     @staticmethod
     def _parse_dipole(line: str, current_dipole: DipoleMoment | None, state: ParseState) -> DipoleMoment | None:

--- a/src/calcflow/io/qchem/blocks/orbitals.py
+++ b/src/calcflow/io/qchem/blocks/orbitals.py
@@ -12,7 +12,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.results import Orbital, OrbitalsSet
 from calcflow.common.types import SpinChannel
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_ORBITALS, ParseState
 from calcflow.utils import logger
 
 # Pattern definitions
@@ -41,7 +41,7 @@ class OrbitalsParser:
         """Check if this line marks the start of the orbital energies block."""
         if "Orbital Energies" not in line:
             return False
-        if state.parsed_orbitals:
+        if BLOCK_ORBITALS in state.parsed_blocks:
             return False
         return bool(ORBITAL_BLOCK_START_PAT.search(line))
 
@@ -174,7 +174,7 @@ class OrbitalsParser:
             beta_lumo_index=beta_lumo_index,
         )
 
-        state.parsed_orbitals = True
+        state.parsed_blocks.add(BLOCK_ORBITALS)
         logger.info(
             f"Parsed orbital energies. Alpha: {len(alpha_orbitals)} orbitals "
             f"(HOMO: {alpha_homo_index}, LUMO: {alpha_lumo_index}). "

--- a/src/calcflow/io/qchem/blocks/scf.py
+++ b/src/calcflow/io/qchem/blocks/scf.py
@@ -5,7 +5,7 @@ from calcflow.common.patterns import VersionSpec
 from calcflow.common.results import ScfIteration, ScfResults, SmdResults
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.patterns import QCHEM_PATTERNS
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_SCF, ParseState
 from calcflow.utils import logger
 
 # --- Non-versioned patterns specific to the SCF block's structure ---
@@ -35,7 +35,7 @@ class ScfParser:
     def matches(self, line: str, state: ParseState) -> bool:
         if "General SCF" not in line:
             return False
-        return not state.parsed_scf and bool(SCF_START_PAT.search(line))
+        return BLOCK_SCF not in state.parsed_blocks and bool(SCF_START_PAT.search(line))
 
     def parse(self, iterator: PeekableIterator, start_line: str, state: ParseState) -> None:
         logger.debug("Starting SCF block parsing.")
@@ -166,7 +166,7 @@ class ScfParser:
         # final energy, falling back to the SCF energy.
         state.final_energy = smd_data.get("g_tot_au", final_energy_data.get("final_energy", final_scf_energy))
 
-        state.parsed_scf = True
+        state.parsed_blocks.add(BLOCK_SCF)
         logger.info(f"Parsed SCF data. Converged: {converged}, Energy: {final_scf_energy:.8f}")
 
     def _process_versioned_patterns(

--- a/src/calcflow/io/qchem/blocks/tddft/excitations.py
+++ b/src/calcflow/io/qchem/blocks/tddft/excitations.py
@@ -19,7 +19,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import extract_index
 from calcflow.common.results import ExcitedState, OrbitalTransition
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_TDDFT_FULL, BLOCK_TDDFT_TDA, ParseState
 from calcflow.utils import logger
 
 # --- Pattern constants ---
@@ -58,7 +58,7 @@ class ExcitationsParser:
         """
         if "Excitation" not in line:
             return False
-        if state.parsed_tddft_tda and state.parsed_tddft_full:
+        if BLOCK_TDDFT_TDA in state.parsed_blocks and BLOCK_TDDFT_FULL in state.parsed_blocks:
             return False
 
         return bool(TDA_START_PAT.search(line) or TDDFT_START_PAT.search(line))
@@ -181,10 +181,10 @@ class ExcitationsParser:
         # --- Update ParseState ---
         # Determine which field to populate based on block type
         if is_tda:
-            state.parsed_tddft_tda = True
+            state.parsed_blocks.add(BLOCK_TDDFT_TDA)
             state.tddft_tda_states = excited_states
         else:  # is_tddft
-            state.parsed_tddft_full = True
+            state.parsed_blocks.add(BLOCK_TDDFT_FULL)
             state.tddft_tddft_states = excited_states
 
         logger.debug(f"Parsed {len(excited_states)} excited states.")

--- a/src/calcflow/io/qchem/blocks/tddft/gs_ref.py
+++ b/src/calcflow/io/qchem/blocks/tddft/gs_ref.py
@@ -17,7 +17,7 @@ from calcflow.common.exceptions import ParsingError
 from calcflow.common.patterns import extract_index
 from calcflow.common.results import AtomicCharges, GroundStateReference
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_TDDFT_GS_REF, ParseState
 from calcflow.utils import logger
 
 # --- Pattern constants ---
@@ -67,7 +67,7 @@ class GroundStateRefParser:
         """
         if "Ground State" not in line:
             return False
-        if state.parsed_tddft_gs_ref:
+        if BLOCK_TDDFT_GS_REF in state.parsed_blocks:
             return False
 
         return bool(GS_REF_START_PAT.search(line))
@@ -229,7 +229,7 @@ class GroundStateRefParser:
         )
 
         # --- Update ParseState ---
-        state.parsed_tddft_gs_ref = True
+        state.parsed_blocks.add(BLOCK_TDDFT_GS_REF)
 
         state.tddft_ground_state_ref = gs_ref
 

--- a/src/calcflow/io/qchem/blocks/tddft/nto.py
+++ b/src/calcflow/io/qchem/blocks/tddft/nto.py
@@ -17,7 +17,7 @@ from typing import cast
 from calcflow.common.results import NTOContribution, NTOStateAnalysis
 from calcflow.common.types import SpinChannel
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_NTO, ParseState
 from calcflow.utils import logger
 
 # --- Pattern constants ---
@@ -56,7 +56,7 @@ class NTOParser:
         """
         if "NTO" not in line:
             return False
-        if state.parsed_nto:
+        if BLOCK_NTO in state.parsed_blocks:
             return False
 
         return bool(NTO_START_PAT.search(line))
@@ -192,12 +192,12 @@ class NTOParser:
 
         if not nto_states:
             state.parsing_warnings.append("SA-NTO decomposition block found but no states parsed.")
-            state.parsed_nto = True
+            state.parsed_blocks.add(BLOCK_NTO)
             return
 
         # --- Update ParseState ---
         state.tddft_nto_analyses = nto_states
-        state.parsed_nto = True
+        state.parsed_blocks.add(BLOCK_NTO)
 
         logger.debug(f"Parsed {len(nto_states)} NTO states.")
 

--- a/src/calcflow/io/qchem/blocks/tddft/trans_dm.py
+++ b/src/calcflow/io/qchem/blocks/tddft/trans_dm.py
@@ -29,6 +29,7 @@ from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.parse_helpers import parse_key_value as _parse_key_value
 from calcflow.io.qchem.blocks.parse_helpers import parse_vector as _parse_vector
 from calcflow.io.qchem.blocks.parse_helpers import to_float as _to_float
+from calcflow.io.state import BLOCK_TDDFT_TRANS_DM
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class TransitionDensityMatrixParser(BlockParser):
     def matches(self, line: str, state: ParseState) -> bool:
         if "Transition Density" not in line:
             return False
-        if state.parsed_tddft_trans_dm:
+        if BLOCK_TDDFT_TRANS_DM in state.parsed_blocks:
             return False
         return bool(self.START_PAT.search(line))
 
@@ -93,7 +94,7 @@ class TransitionDensityMatrixParser(BlockParser):
             logger.warning(msg)
             return
 
-        state.parsed_tddft_trans_dm = True
+        state.parsed_blocks.add(BLOCK_TDDFT_TRANS_DM)
         state.tddft_transition_density_matrices = all_analyses
         logger.debug("Finished parsing 'Transition Density Matrix Analysis'.")
 

--- a/src/calcflow/io/qchem/blocks/tddft/unrel_dm.py
+++ b/src/calcflow/io/qchem/blocks/tddft/unrel_dm.py
@@ -29,6 +29,7 @@ from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.parse_helpers import parse_key_value as _parse_key_value
 from calcflow.io.qchem.blocks.parse_helpers import parse_vector as _parse_vector
 from calcflow.io.qchem.blocks.parse_helpers import to_float as _to_float
+from calcflow.io.state import BLOCK_TDDFT_UNRELAXED_DM
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class UnrelaxedDensityMatrixParser(BlockParser):
     def matches(self, line: str, state: ParseState) -> bool:
         if "Unrelaxed" not in line:
             return False
-        if state.parsed_tddft_unrelaxed_dm:
+        if BLOCK_TDDFT_UNRELAXED_DM in state.parsed_blocks:
             return False
         return bool(self.START_PAT.search(line))
 
@@ -93,7 +94,7 @@ class UnrelaxedDensityMatrixParser(BlockParser):
             logger.warning(msg)
             return
 
-        state.parsed_tddft_unrelaxed_dm = True
+        state.parsed_blocks.add(BLOCK_TDDFT_UNRELAXED_DM)
         state.tddft_unrelaxed_density_matrices = all_analyses
         logger.debug("Finished parsing 'Analysis of Unrelaxed Density Matrices'.")
 

--- a/src/calcflow/io/qchem/blocks/timing.py
+++ b/src/calcflow/io/qchem/blocks/timing.py
@@ -9,7 +9,7 @@ import re
 
 from calcflow.common.results import TimingResults
 from calcflow.io.peekable import PeekableIterator
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_TIMING, ParseState
 from calcflow.utils import logger
 
 # Pattern for total job time: "Total job time:  0.77s(wall), 0.22s(cpu)"
@@ -25,7 +25,7 @@ class TimingParser:
         """Matches on the total job time line."""
         if "Total job time" not in line:
             return False
-        if state.parsed_timing:
+        if BLOCK_TIMING in state.parsed_blocks:
             return False
         return bool(TOTAL_TIME_PAT.search(line))
 
@@ -42,5 +42,5 @@ class TimingParser:
                 total_wall_time_seconds=wall_time,
                 total_cpu_time_seconds=cpu_time,
             )
-            state.parsed_timing = True
+            state.parsed_blocks.add(BLOCK_TIMING)
             logger.debug(f"Parsed timing: wall={wall_time}s, cpu={cpu_time}s")

--- a/src/calcflow/io/state.py
+++ b/src/calcflow/io/state.py
@@ -28,6 +28,29 @@ from calcflow.common.results import (
 )
 from calcflow.geometry.static import Geometry
 
+# Block name constants for use with ParseState.parsed_blocks.
+# Each constant names a parser block that tracks its own completion state.
+BLOCK_METADATA = "metadata"
+BLOCK_GEOMETRY = "geometry"
+BLOCK_SCF = "scf"
+BLOCK_ORBITALS = "orbitals"
+BLOCK_MULLIKEN = "mulliken"
+BLOCK_LOEWDIN = "loewdin"
+BLOCK_HIRSHFELD = "hirshfeld"
+BLOCK_CM5 = "cm5"
+BLOCK_DIPOLE = "dipole"
+BLOCK_DISPERSION = "dispersion"
+BLOCK_MULTIPOLE = "multipole"
+BLOCK_TIMING = "timing"
+BLOCK_TDDFT_TDA = "tddft_tda"
+BLOCK_TDDFT_FULL = "tddft_full"
+BLOCK_TDDFT_GS_REF = "tddft_gs_ref"
+BLOCK_TDDFT_UNRELAXED_DM = "tddft_unrelaxed_dm"
+BLOCK_TDDFT_TRANS_DM = "tddft_trans_dm"
+BLOCK_NTO = "nto"
+BLOCK_ADC_GS = "adc_gs"
+BLOCK_ADC_EXCITED = "adc_excited"
+
 
 class ParseState:
     """
@@ -71,27 +94,8 @@ class ParseState:
         self.tddft_transition_density_matrices: list[TransitionDensityMatrix] = []
 
         # --- Parser Control Flags ---
-        self.parsed_metadata: bool = False
-        self.parsed_geometry: bool = False
-        self.parsed_scf: bool = False
-        self.parsed_orbitals: bool = False
-        self.parsed_mulliken: bool = False
-        self.parsed_loewdin: bool = False
-        self.parsed_hirshfeld: bool = False
-        self.parsed_cm5: bool = False
-        self.parsed_dipole: bool = False
-        self.parsed_dispersion: bool = False
-        self.parsed_multipole: bool = False
-        self.parsed_timing: bool = False
-        self.parsed_tddft_tda: bool = False
-        self.parsed_tddft_full: bool = False
-        self.parsed_tddft_gs_ref: bool = False
-        self.parsed_tddft_unrelaxed_dm: bool = False
-        self.parsed_tddft_trans_dm: bool = False
-        self.parsed_nto: bool = False
-        self.parsed_adc_gs: bool = False
-        self.parsed_adc_excited: bool = False
-        # Add more as needed for other parsers...
+        # Set of block names that have been fully parsed. Use BLOCK_* constants as keys.
+        self.parsed_blocks: set[str] = set()
 
         # --- Communication & Error Handling ---
         self.parsing_errors: list[str] = []

--- a/tests/io/qchem/qchem_parsers/adc/test_qchem_adc_excited_states.py
+++ b/tests/io/qchem/qchem_parsers/adc/test_qchem_adc_excited_states.py
@@ -16,7 +16,7 @@ import pytest
 
 from calcflow.common.results import AdcExcitedState, CalculationResult
 from calcflow.io.qchem.blocks.adc.excited_states import AdcExcitedStatesParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_ADC_EXCITED, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -95,7 +95,7 @@ def test_adc_excited_states_parser_does_not_match_non_summary_lines() -> None:
 def test_adc_excited_states_parser_skips_if_already_parsed() -> None:
     parser = AdcExcitedStatesParser()
     state = ParseState(raw_output="")
-    state.parsed_adc_excited = True
+    state.parsed_blocks.add(BLOCK_ADC_EXCITED)
 
     assert parser.matches("                             Excited State Summary", state) is False
 
@@ -111,7 +111,7 @@ def test_adc_excited_states_parser_does_not_mutate_state_in_matches() -> None:
 
     assert result_1 is True
     assert result_2 is True
-    assert state.parsed_adc_excited is False
+    assert BLOCK_ADC_EXCITED not in state.parsed_blocks
     assert state.adc_excited_states == []
 
 

--- a/tests/io/qchem/qchem_parsers/adc/test_qchem_adc_ground_state.py
+++ b/tests/io/qchem/qchem_parsers/adc/test_qchem_adc_ground_state.py
@@ -16,7 +16,7 @@ import pytest
 
 from calcflow.common.results import AdcGroundState, AdcResults, CalculationResult
 from calcflow.io.qchem.blocks.adc.ground_state import AdcGroundStateParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_ADC_GS, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -70,7 +70,7 @@ def test_adc_ground_state_parser_does_not_match_non_adc_lines() -> None:
 def test_adc_ground_state_parser_skips_if_already_parsed() -> None:
     parser = AdcGroundStateParser()
     state = ParseState(raw_output="")
-    state.parsed_adc_gs = True
+    state.parsed_blocks.add(BLOCK_ADC_GS)
 
     assert (
         parser.matches("|                                 A D C  M A N                                 |", state)
@@ -89,7 +89,7 @@ def test_adc_ground_state_parser_does_not_mutate_state_in_matches() -> None:
 
     assert result_1 is True
     assert result_2 is True
-    assert state.parsed_adc_gs is False
+    assert BLOCK_ADC_GS not in state.parsed_blocks
     assert state.adc_ground_state is None
 
 

--- a/tests/io/qchem/qchem_parsers/tddft/test_qchem_tddft_excitations.py
+++ b/tests/io/qchem/qchem_parsers/tddft/test_qchem_tddft_excitations.py
@@ -24,7 +24,7 @@ import pytest
 
 from calcflow.common.results import CalculationResult, ExcitedState, OrbitalTransition, TddftResults
 from calcflow.io.qchem.blocks.tddft.excitations import ExcitationsParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_TDDFT_FULL, BLOCK_TDDFT_TDA, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -139,8 +139,8 @@ def test_excitations_parser_skips_if_already_parsed():
     """Unit test: verify ExcitationsParser.matches() returns False when already parsed."""
     parser = ExcitationsParser()
     state = ParseState(raw_output="")
-    state.parsed_tddft_tda = True
-    state.parsed_tddft_full = True
+    state.parsed_blocks.add(BLOCK_TDDFT_TDA)
+    state.parsed_blocks.add(BLOCK_TDDFT_FULL)
 
     assert parser.matches("          TDDFT/TDA Excitation Energies", state) is False
 
@@ -150,7 +150,7 @@ def test_excitations_parser_matches_tda_even_if_full_parsed():
     """Unit test: verify TDA can be parsed after full TDDFT."""
     parser = ExcitationsParser()
     state = ParseState(raw_output="")
-    state.parsed_tddft_full = True
+    state.parsed_blocks.add(BLOCK_TDDFT_FULL)
 
     # Should still match TDA
     assert parser.matches("          TDDFT/TDA Excitation Energies", state) is True
@@ -161,7 +161,7 @@ def test_excitations_parser_matches_tddft_even_if_tda_parsed():
     """Unit test: verify full TDDFT can be parsed after TDA."""
     parser = ExcitationsParser()
     state = ParseState(raw_output="")
-    state.parsed_tddft_tda = True
+    state.parsed_blocks.add(BLOCK_TDDFT_TDA)
 
     # Should still match full TDDFT
     assert parser.matches("              TDDFT Excitation Energies", state) is True
@@ -182,8 +182,8 @@ def test_excitations_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_tddft_tda is False  # Should NOT be set
-    assert state.parsed_tddft_full is False
+    assert BLOCK_TDDFT_TDA not in state.parsed_blocks  # Should NOT be set
+    assert BLOCK_TDDFT_FULL not in state.parsed_blocks
     assert state.tddft_tda_states == []  # Should NOT be populated
 
 

--- a/tests/io/qchem/qchem_parsers/tddft/test_qchem_tddft_nto.py
+++ b/tests/io/qchem/qchem_parsers/tddft/test_qchem_tddft_nto.py
@@ -22,7 +22,7 @@ import pytest
 
 from calcflow.common.results import CalculationResult, NTOStateAnalysis
 from calcflow.io.qchem.blocks.tddft.nto import NTOParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_NTO, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -213,7 +213,7 @@ def test_nto_parser_skips_if_already_parsed():
     """Unit test: verify NTOParser.matches() returns False when already parsed."""
     parser = NTOParser()
     state = ParseState(raw_output="")
-    state.parsed_nto = True
+    state.parsed_blocks.add(BLOCK_NTO)
 
     assert parser.matches("  SA-NTO Decomposition", state) is False
 
@@ -233,7 +233,7 @@ def test_nto_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_nto is False  # Should NOT be set
+    assert BLOCK_NTO not in state.parsed_blocks  # Should NOT be set
 
 
 # =============================================================================

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_charges.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_charges.py
@@ -15,7 +15,7 @@ import pytest
 
 from calcflow.common.results import AtomicCharges, CalculationResult
 from calcflow.io.qchem.blocks.charges import MullikenParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_MULLIKEN, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -75,7 +75,7 @@ def test_mulliken_parser_skips_if_already_parsed():
     """Unit test: verify MullikenParser.matches() returns False when already parsed."""
     parser = MullikenParser()
     state = ParseState(raw_output="")
-    state.parsed_mulliken = True
+    state.parsed_blocks.add(BLOCK_MULLIKEN)
 
     start_line = "Ground-State Mulliken Net Atomic Charges"
     assert parser.matches(start_line, state) is False
@@ -96,7 +96,7 @@ def test_mulliken_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_mulliken is False  # Should NOT be set
+    assert BLOCK_MULLIKEN not in state.parsed_blocks  # Should NOT be set
     assert state.atomic_charges == []  # Should NOT be populated
 
 

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_cm5.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_cm5.py
@@ -17,7 +17,7 @@ import pytest
 from calcflow.common.results import AtomicCharges, CalculationResult
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.cm5 import Cm5Parser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_CM5, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -74,7 +74,7 @@ def test_cm5_parser_skips_if_already_parsed():
     """Unit test: verify Cm5Parser.matches() returns False when already parsed."""
     parser = Cm5Parser()
     state = ParseState(raw_output="")
-    state.parsed_cm5 = True
+    state.parsed_blocks.add(BLOCK_CM5)
 
     assert parser.matches("          Charge Model 5         ", state) is False
 
@@ -91,7 +91,7 @@ def test_cm5_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_cm5 is False
+    assert BLOCK_CM5 not in state.parsed_blocks
     assert state.atomic_charges == []
 
 
@@ -113,7 +113,7 @@ def test_cm5_parser_parse_basic():
     ]
     parser.parse(PeekableIterator(iter(lines)), "          Charge Model 5         ", state)
 
-    assert state.parsed_cm5 is True
+    assert BLOCK_CM5 in state.parsed_blocks
     assert len(state.atomic_charges) == 1
     cm5 = state.atomic_charges[0]
     assert cm5.method == "CM5"
@@ -148,7 +148,7 @@ def test_cm5_parser_empty_block_adds_warning():
 
     parser.parse(PeekableIterator(iter(["  Sum of atomic charges =     0.000000"])), "Charge Model 5", state)
 
-    assert state.parsed_cm5 is False
+    assert BLOCK_CM5 not in state.parsed_blocks
     assert len(state.atomic_charges) == 0
     assert len(state.parsing_warnings) == 1
 

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py
@@ -11,7 +11,7 @@ import pytest
 from calcflow.common.results import Atom, CalculationResult
 from calcflow.geometry.static import Geometry
 from calcflow.io.qchem.blocks.geometry import GeometryParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_GEOMETRY, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # Tolerance for coordinate precision (7 decimal places)
@@ -67,7 +67,7 @@ def test_geometry_parser_skips_molecule_if_already_parsed():
     """
     parser = GeometryParser()
     state = ParseState(raw_output="")
-    state.parsed_geometry = True
+    state.parsed_blocks.add(BLOCK_GEOMETRY)
 
     molecule_line = "$molecule"
     assert parser.matches(molecule_line, state) is False

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_hirshfeld.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_hirshfeld.py
@@ -16,7 +16,7 @@ import pytest
 from calcflow.common.results import AtomicCharges, CalculationResult
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.hirshfeld import HirshfeldParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_HIRSHFELD, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -73,7 +73,7 @@ def test_hirshfeld_parser_skips_if_already_parsed():
     """Unit test: verify HirshfeldParser.matches() returns False when already parsed."""
     parser = HirshfeldParser()
     state = ParseState(raw_output="")
-    state.parsed_hirshfeld = True
+    state.parsed_blocks.add(BLOCK_HIRSHFELD)
 
     assert parser.matches("          Hirshfeld Atomic Charges         ", state) is False
 
@@ -90,7 +90,7 @@ def test_hirshfeld_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_hirshfeld is False
+    assert BLOCK_HIRSHFELD not in state.parsed_blocks
     assert state.atomic_charges == []
 
 
@@ -112,7 +112,7 @@ def test_hirshfeld_parser_parse_basic():
     ]
     parser.parse(PeekableIterator(iter(lines)), "          Hirshfeld Atomic Charges         ", state)
 
-    assert state.parsed_hirshfeld is True
+    assert BLOCK_HIRSHFELD in state.parsed_blocks
     assert len(state.atomic_charges) == 1
     hirshfeld = state.atomic_charges[0]
     assert hirshfeld.method == "Hirshfeld"
@@ -147,7 +147,7 @@ def test_hirshfeld_parser_empty_block_adds_warning():
 
     parser.parse(PeekableIterator(iter(["  Sum of atomic charges =     0.000000"])), "Hirshfeld Atomic Charges", state)
 
-    assert state.parsed_hirshfeld is False
+    assert BLOCK_HIRSHFELD not in state.parsed_blocks
     assert len(state.atomic_charges) == 0
     assert len(state.parsing_warnings) == 1
 

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_meta.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_meta.py
@@ -12,7 +12,7 @@ from calcflow.common.patterns import VersionSpec
 from calcflow.common.results import CalculationMetadata
 from calcflow.io.peekable import PeekableIterator
 from calcflow.io.qchem.blocks.metadata import MetadataParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_METADATA, ParseState
 
 
 @pytest.mark.unit
@@ -77,7 +77,7 @@ def test_metadata_parser_sets_software_name_and_version():
 
     assert state.metadata.software_name == "Q-Chem"
     assert state.metadata.software_version == "6.2"
-    assert state.parsed_metadata is True
+    assert BLOCK_METADATA in state.parsed_blocks
 
 
 @pytest.mark.unit

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_multipole.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_multipole.py
@@ -16,7 +16,7 @@ import pytest
 
 from calcflow.common.results import CalculationResult, MultipoleResults
 from calcflow.io.qchem.blocks.multipole import MultipoleParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_MULTIPOLE, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -111,7 +111,7 @@ def test_multipole_parser_skips_if_already_parsed():
     """Unit test: verify MultipoleParser.matches() returns False when already parsed."""
     parser = MultipoleParser()
     state = ParseState(raw_output="")
-    state.parsed_multipole = True
+    state.parsed_blocks.add(BLOCK_MULTIPOLE)
 
     start_line = "Multipole moment tensor (Debye.Ang**n / e.Bohr**n)"
     assert parser.matches(start_line, state) is False
@@ -134,7 +134,7 @@ def test_multipole_parser_does_not_mutate_state_in_matches():
     # State should be identical after calling matches()
     assert result1 is True
     assert result2 is True
-    assert state.parsed_multipole is False  # Should NOT be set
+    assert BLOCK_MULTIPOLE not in state.parsed_blocks  # Should NOT be set
     assert state.multipole is None  # Should NOT be populated
 
 

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_orbitals.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_orbitals.py
@@ -21,7 +21,7 @@ import pytest
 
 from calcflow.common.results import CalculationResult, Orbital, OrbitalsSet
 from calcflow.io.qchem.blocks.orbitals import OrbitalsParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_ORBITALS, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -80,7 +80,7 @@ def test_orbitals_parser_skips_if_already_parsed():
     """Unit test: verify OrbitalsParser.matches() returns False when already parsed."""
     parser = OrbitalsParser()
     state = ParseState(raw_output="")
-    state.parsed_orbitals = True
+    state.parsed_blocks.add(BLOCK_ORBITALS)
 
     assert parser.matches("                    Orbital Energies (a.u.)", state) is False
 
@@ -100,7 +100,7 @@ def test_orbitals_parser_does_not_mutate_state_in_matches():
 
     assert result1 is True
     assert result2 is True
-    assert state.parsed_orbitals is False  # Should NOT be set
+    assert BLOCK_ORBITALS not in state.parsed_blocks  # Should NOT be set
     assert state.orbitals is None  # Should NOT be populated
 
 

--- a/tests/io/qchem/qchem_parsers/test_qchem_sp_scf.py
+++ b/tests/io/qchem/qchem_parsers/test_qchem_sp_scf.py
@@ -21,7 +21,7 @@ import pytest
 
 from calcflow.common.results import CalculationResult, ScfIteration, ScfResults, SmdResults
 from calcflow.io.qchem.blocks.scf import ScfParser
-from calcflow.io.state import ParseState
+from calcflow.io.state import BLOCK_SCF, ParseState
 from tests.io.qchem.qchem_parsers.conftest import FIXTURE_SPECS
 
 # =============================================================================
@@ -97,7 +97,7 @@ def test_scf_parser_skips_if_already_parsed():
     """Unit test: verify ScfParser.matches() returns False when already parsed."""
     parser = ScfParser()
     state = ParseState(raw_output="")
-    state.parsed_scf = True
+    state.parsed_blocks.add(BLOCK_SCF)
 
     start_line = " General SCF calculation program by"
     assert parser.matches(start_line, state) is False
@@ -120,7 +120,7 @@ def test_scf_parser_does_not_mutate_state_in_matches():
     # State should be identical after calling matches()
     assert result1 is True
     assert result2 is True
-    assert state.parsed_scf is False  # Should NOT be set
+    assert BLOCK_SCF not in state.parsed_blocks  # Should NOT be set
     assert state.scf is None  # Should NOT be populated
 
 


### PR DESCRIPTION
## Summary

- Replaces 20 individual `parsed_*: bool` fields on `ParseState` with a single `parsed_blocks: set[str]` field
- Adds 20 `BLOCK_*` string constants to `state.py` (e.g., `BLOCK_SCF = "scf"`) as canonical keys
- Updates all 23 parser files (Q-Chem + ORCA) and 12 test files to use the new API

## Motivation

Adding a new parser previously required adding a `parsed_<name>: bool = False` field to `state.py`. Now it only requires defining a constant and using `state.parsed_blocks.add(BLOCK_NAME)` / `BLOCK_NAME in state.parsed_blocks`. The 20-line `__init__` block is collapsed to one line.

## Semantics

Identical to before — set membership (`in`) is O(1) like a boolean read, and `set.add()` is O(1) like an assignment. The `to_calculation_result()` method is unchanged (it never read `parsed_*` flags).

## Verification

All 1924 tests pass unchanged. Lint and format clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a clean structural refactoring of `ParseState` in `src/calcflow/io/state.py`: 20 individual `parsed_*: bool` fields are replaced with a single `parsed_blocks: set[str]` field, and 20 `BLOCK_*` string constants are added as canonical keys. All 23 parser files and 12 test files are updated consistently to use the new API.

**Key changes:**
- `ParseState.__init__` is simplified from 20 boolean assignments to `self.parsed_blocks: set[str] = set()`
- 20 `BLOCK_*` string constants (e.g., `BLOCK_SCF = "scf"`) are added to `state.py` as the authoritative keys
- All `state.parsed_X` boolean reads are replaced with `BLOCK_X in state.parsed_blocks`, and all `state.parsed_X = True` writes are replaced with `state.parsed_blocks.add(BLOCK_X)`
- Semantics are fully preserved — set membership is O(1) just like a boolean read

**Issues found:**
- `AGENTS.md` (not in this PR's changeset) contains a stale example in the "Adding parser" instructions: `state.parsed_scf = True`. This should be updated to `state.parsed_blocks.add(BLOCK_SCF)` to keep the developer guide accurate.
- Two minor stale comments in changed files reference the old `parsed_geometry flag` naming (see inline comments).

<h3>Confidence Score: 5/5</h3>

- Safe to merge — pure refactoring with no behavioral changes, all 1924 tests pass, and semantics are identical to the boolean-flag approach.
- The change is a mechanical, semantics-preserving refactoring. Every boolean check and assignment has been correctly replaced with a set membership test and `set.add()`. No logic branches were changed. The only gaps found are a stale comment and docstring in the changed files, and one stale developer-guide example in AGENTS.md (not part of this PR).
- No files require special attention — all parser and test files are consistently updated.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/calcflow/io/state.py | Core change: 20 individual boolean fields removed and replaced with a single `parsed_blocks: set[str]` field, plus 20 `BLOCK_*` string constants added. Clean and correct. |
| src/calcflow/io/qchem/blocks/geometry.py | Logic correctly updated to use `BLOCK_GEOMETRY in state.parsed_blocks`, but inline comment on line 40 still references the old "parsed_geometry flag" naming. |
| tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py | Test logic correctly updated to use `BLOCK_GEOMETRY` and `state.parsed_blocks`, but test docstring on line 66 still references the old `parsed_geometry flag is True` phrasing. |
| src/calcflow/io/orca/blocks/charges.py | Both MULLIKEN and LOEWDIN flag checks and additions correctly migrated to `parsed_blocks` set. |
| src/calcflow/io/qchem/blocks/tddft/excitations.py | Both TDDFT_TDA and TDDFT_FULL block checks and additions correctly migrated; short-circuit in `matches()` is correct. |
| src/calcflow/io/orca/blocks/scf.py | SCF parser correctly uses `BLOCK_SCF not in state.parsed_blocks` for guard and `state.parsed_blocks.add(BLOCK_SCF)` at completion. |
| tests/io/qchem/qchem_parsers/test_qchem_sp_scf.py | Tests correctly updated to assert `BLOCK_SCF not in state.parsed_blocks` before parsing and use the new set-based API. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Line from output file] --> B{BlockParser.matches\nline, state}
    B -->|Check| C{"BLOCK_X in\nstate.parsed_blocks?"}
    C -->|Yes - already parsed| D[Return False\nskip this parser]
    C -->|No| E{Pattern match\non line?}
    E -->|No match| D
    E -->|Matches| F[Return True]
    F --> G[BlockParser.parse\niterator, line, state]
    G --> H[Parse lines\nfrom iterator]
    H --> I[Write result to\nstate e.g. state.scf]
    I --> J[state.parsed_blocks.add\nBLOCK_X]
    J --> K[Block complete\nskipped on future lines]

    style J fill:#22c55e,color:#fff
    style C fill:#3b82f6,color:#fff
    style D fill:#ef4444,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py`, line 63-67 ([link](https://github.com/ischemist/project-prometheus/blob/c1ff5b12b37f12605245902c4f7ae3d324714d47/tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py#L63-L67)) 

   **Stale docstring references old boolean flag**

   The docstring says `parsed_geometry flag is True`, which refers to the old `ParseState.parsed_geometry: bool` field that this PR removes. The description should be updated to describe the new mechanism.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py
   Line: 63-67

   Comment:
   **Stale docstring references old boolean flag**

   The docstring says `parsed_geometry flag is True`, which refers to the old `ParseState.parsed_geometry: bool` field that this PR removes. The description should be updated to describe the new mechanism.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/calcflow/io/qchem/blocks/geometry.py
Line: 40

Comment:
**Stale inline comment references old boolean flag**

The comment still mentions a `'parsed_geometry'` flag, which was the old boolean-field API. With this PR's refactoring, the terminology should reference the new `parsed_blocks` set.

```suggestion
            # We use BLOCK_GEOMETRY in parsed_blocks to track the input geometry
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/io/qchem/qchem_parsers/test_qchem_sp_geometry.py
Line: 63-67

Comment:
**Stale docstring references old boolean flag**

The docstring says `parsed_geometry flag is True`, which refers to the old `ParseState.parsed_geometry: bool` field that this PR removes. The description should be updated to describe the new mechanism.

```suggestion
def test_geometry_parser_skips_molecule_if_already_parsed():
    """
    Unit test: verify GeometryParser.matches() returns False when input geometry
    is already parsed (BLOCK_GEOMETRY is in state.parsed_blocks).
    """
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: c1ff5b1</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->