### PR TITLE
enforce a 7-day uv package cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
     cooldown:
       default-days: 7
     labels:
-      - "type/security"
+      - "scope/ci-cd"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
-      - "type/security"
+      - "scope/ci-cd"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,3 @@ updates:
       interval: "weekly"
     labels:
       - "type/security"
-      - "scope/ci-cd"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels:
+      - "type/security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "type/security"
+      - "scope/ci-cd"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         run: uv run pytest -v

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run ty
         run: uv run ty check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 # Delay newly uploaded artifacts to reduce exposure to malicious fresh releases.
-required-version = ">=0.5.0"
+required-version = ">=0.9.17"
 exclude-newer = "7 days"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 # Delay newly uploaded artifacts to reduce exposure to malicious fresh releases.
+required-version = ">=0.5.0"
 exclude-newer = "7 days"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ Issues = "https://github.com/ischemist/project-prometheus/issues"
 requires = ["setuptools>=61.0", "wheel", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv]
+# Delay newly uploaded artifacts to reduce exposure to malicious fresh releases.
+exclude-newer = "7 days"
+
 [tool.setuptools]
 package-dir = { "" = "src" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "calcflow"
 source = { editable = "." }


### PR DESCRIPTION
## why
newly uploaded package artifacts are a high-risk supply-chain window. this change hardens `uv` resolution and ci install behavior so fresh registry artifacts are avoided, and the repo requires a new enough `uv` to understand the cooldown syntax.

for dependabot, the goal here is routine maintenance triage, not a fake security/non-security split that `dependabot.yml` cannot express on its own.

## what changed
added repo-level `tool.uv` policy to exclude artifacts uploaded within the last 7 days and require `uv >= 0.9.17`, which is the release that added relative durations for `exclude-newer`.

updated github actions installs to `uv sync --locked` so ci uses the committed lockfile instead of silently re-resolving.

added `.github/dependabot.yml` with weekly checks, a matching 7-day cooldown for `uv` updates, and `scope/ci-cd` labels for routine dependabot prs.

updated the committed `uv.lock` metadata to record the relative exclusion window.

## risk
low risk. this changes dependency resolution and update automation, not runtime application logic.

review focus is whether the 7-day cooldown is the right operational tradeoff and whether any workflow still relies on unlocked dependency resolution.

## verification
ran `uv lock`.

ran `uv lock --check`.

ran `uv sync --locked`.

ran `uv run pytest -q` with `1924 passed in 1.12s` before the follow-up, `1924 passed in 0.84s` after the dependabot changes, and `1924 passed in 0.90s` after bumping the `uv` minimum version.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the repository's supply-chain posture by enforcing a 7-day artifact cooldown via `[tool.uv]` in `pyproject.toml`, switching both CI workflows from `uv sync` to `uv sync --locked`, and adding a `dependabot.yml` with matching cooldown and weekly schedules.

- **`pyproject.toml`**: Adds `exclude-newer = "7 days"` to filter packages uploaded in the last 7 days during resolution, guarded by `required-version = ">=0.9.17"` which is the version that introduced relative exclusion windows.
- **Workflows (`tests.yml`, `typing.yml`)**: Switch to `uv sync --locked` so CI installs exactly what is in the committed lockfile instead of silently re-resolving.
- **`dependabot.yml`**: Introduces weekly dependency checks with a 7-day cooldown for the `uv` ecosystem; `github-actions` intentionally omits a cooldown per the PR's stated scope.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to tooling configuration and do not touch runtime application logic.

The required-version = ">=0.9.17" correctly gates the relative exclude-newer format, the lockfile metadata is consistent with the pyproject.toml policy, and uv sync --locked in CI is the right call now that a committed lockfile is the source of truth. No application code is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds [tool.uv] with exclude-newer = "7 days" and required-version = ">=0.9.17" — the minimum version that supports relative exclusion windows. Clean. |
| .github/dependabot.yml | New file with valid cooldown configuration for the uv ecosystem (7 days) and weekly github-actions updates. The cooldown field is supported as of July 2025. |
| .github/workflows/tests.yml | uv sync changed to uv sync --locked; cache key still hashes only pyproject.toml (pre-existing gap, already flagged in previous review). |
| .github/workflows/typing.yml | Same --locked change as tests.yml; same pre-existing cache key gap applies. |
| uv.lock | Adds [options] block with exclude-newer-span = "P7D" and the zero-epoch timestamp stub for backwards compatibility. Consistent with pyproject.toml policy. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / Dependabot] --> B{Run uv lock?}
    B -->|Yes| C[uv checks required-version >= 0.9.17]
    C --> D{Version OK?}
    D -->|No| E[Hard fail: version mismatch error]
    D -->|Yes| F[Apply exclude-newer = 7 days filter]
    F --> G{Package uploaded < 7 days ago?}
    G -->|Yes| H[Excluded from resolution]
    G -->|No| I[Included in lockfile]
    I --> J[uv.lock updated with exclude-newer-span = P7D]
    B -->|No, CI uv sync locked| K[Read committed uv.lock]
    K --> L[Install exact pinned versions]
    L --> M[Tests / Type checks run]
    N[Dependabot weekly check] --> O{Package age >= 7 days cooldown?}
    O -->|No| P[Skip PR]
    O -->|Yes| Q[Open update PR with scope/ci-cd label]
    Q --> B
```

<sub>Reviews (4): Last reviewed commit: ["require uv 0.9.17 for relative cooldowns"](https://github.com/ischemist/project-prometheus/commit/01d47b111c4dcb1b502a0191a1d5375308fd191b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31701365)</sub>

<!-- /greptile_comment -->